### PR TITLE
Add draft CI workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 * @Sage-Bionetworks-Workflows/admins
-

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: pre-commit/action@v2.0.0
 
   sceptre-deploy:
-    if: ${{ github.event_name == 'push' }}
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: pre-commit
     steps:
@@ -43,26 +43,34 @@ jobs:
           WORKON_HOME: ~/.local/share/virtualenvs
           PIPENV_CACHE_DIR: ~/.local/share/pipcache
         run: pipenv install --dev
-      - name: Login as AWS Service User (Under Dev Account)
+      - name: Assume AWS Role (Dev Account)
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - name: Deploy both 'dev' and 'prod' stack groups to 'dev' account using sceptre
+          role-to-assume: arn:aws:iam::035458030717:role/SceptreBuildAccessRole
+          role-duration-seconds: 1200
+      - name: Deploy 'dev' and 'prod' Stack Groups to Dev Account
         run: |
+          pipenv shell
           sceptre launch dev --yes
           sceptre launch prod --yes
+
+      # Commented out until the AWS account becomes available. Track this PR:
+      # https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/135
+
       # - name: Assume AWS Role (Prod Account)
       #   uses: aws-actions/configure-aws-credentials@v1
-      #   if: ${{ github.ref == 'refs/heads/main' }}
+      #   if: github.ref == 'refs/heads/main'
       #   with:
       #     aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
       #     aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
       #     aws-region: us-east-1
-      #     role-to-assume: arn:aws:iam::0987654321:role/NextflowWorkflows-CIServiceRole
+      #     role-to-assume: arn:aws:iam::0123456789:role/SceptreBuildAccessRole
       #     role-duration-seconds: 1200
-      # - name: Deploy both 'prod' stack groups to 'prod' account using sceptre
-      #   if: ${{ github.ref == 'refs/heads/main' }}
+      # - name: Deploy 'prod' Stack Group to Prod Account
+      #   if: github.ref == 'refs/heads/main'
       #   run: |
+      #     pipenv shell
       #     sceptre launch prod --yes

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2
+      - uses: pre-commit/action@v2.0
 
   sceptre-validate:
     name: Validate CloudFormation templates using sceptre

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -26,4 +26,5 @@ jobs:
       - name: Deploy 'prod' templates
         uses: Rurquhart/sceptre-action@v1.0
         with:
-          sceptre_subcommand: launch --yes dev
+          sceptre_version: 2.4.0
+          sceptre_subcommand: launch --yes prod

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -2,10 +2,6 @@ name: aws-deploy
 
 on: push
 
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.NEXTFLOW_PROD_CI_ACCESS_KEY }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.NEXTFLOW_PROD_CI_SECRET_ACCESS_KEY }}
-
 jobs:
   pre-commit:
     name: Run pre-commit hooks against all files
@@ -23,6 +19,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.NEXTFLOW_PROD_CI_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.NEXTFLOW_PROD_CI_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::728882028485:role/workflows-nextflow-ci-service-account-ServiceRole-CTLXKJIOCRO4
+          role-duration-seconds: 1200
       - name: Deploy 'prod' templates
         uses: Rurquhart/sceptre-action@v1.0
         with:

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -1,54 +1,41 @@
-name: aws-deploy
+name: Validate and Deploy CloudFormation Templates
 
-on:
-  pull_request:
-    branches: '*'
-  push:
-    branches: [prod]
+on: push
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.NEXTFLOW_PROD_CI_ACCESS_KEY }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.NEXTFLOW_PROD_CI_SECRET_ACCESS_KEY }}
 
 jobs:
-
   pre-commit:
+    name: Run pre-commit hooks against all files
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v2
 
-  sceptre-deploy:
-    if: github.event_name == 'push'
+  sceptre-validate:
+    name: Validate CloudFormation templates using sceptre
     runs-on: ubuntu-latest
     needs: pre-commit
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Validate 'prod' templates
+        uses: Rurquhart/sceptre-action@v1
         with:
-          python-version: 3.8
-      - name: Cache Pipenv virtualenv
-        uses: actions/cache@v2
-        id: pipenv-cache
+          sceptre_subcommand: validate prod
+
+  sceptre-deploy:
+    name: Deploy CloudFormation templates using sceptre
+    runs-on: ubuntu-latest
+    needs: sceptre-validate
+    if: github.ref == 'refs/heads/prod'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Deploy 'prod' templates
+        uses: Rurquhart/sceptre-action@v1
         with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-pipenv-v2-${{ hashFiles('**/Pipfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pipenv-v2-
-      - name: Install Dependencies
-        uses: VaultVulp/action-pipenv@v2.0.1
-        if: steps.pipenv-cache.outputs.cache-hit != 'true'
-        env:
-          PIPENV_NOSPIN: 'true'
-          WORKON_HOME: ~/.local/share/virtualenvs
-          PIPENV_CACHE_DIR: ~/.local/share/pipcache
-        with:
-          command: install --dev
-      - name: Login Using CI Service User
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.NEXTFLOW_PROD_CI_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.NEXTFLOW_PROD_CI_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Deploy to AWS Account
-        uses: VaultVulp/action-pipenv@v2.0.1
-        with:
-          command: run sceptre launch prod --yes
+          sceptre_subcommand: launch --yes dev

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Validate 'prod' templates
-        uses: Rurquhart/sceptre-action@v1
+        uses: Rurquhart/sceptre-action@v1.0
         with:
           sceptre_subcommand: validate prod
 
@@ -36,6 +36,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Deploy 'prod' templates
-        uses: Rurquhart/sceptre-action@v1
+        uses: Rurquhart/sceptre-action@v1.0
         with:
           sceptre_subcommand: launch --yes dev

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -25,9 +25,6 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - name: Install pipenv
-        run: |
-          pip install pipenv
       - name: Cache Pipenv virtualenv
         uses: actions/cache@v2
         id: pipenv-cache
@@ -37,30 +34,35 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pipenv-v2-
       - name: Install Dependencies
+        uses: VaultVulp/action-pipenv@v2.0.1
         if: steps.pipenv-cache.outputs.cache-hit != 'true'
         env:
           PIPENV_NOSPIN: 'true'
           WORKON_HOME: ~/.local/share/virtualenvs
           PIPENV_CACHE_DIR: ~/.local/share/pipcache
-        run: pipenv install --dev
-      - name: Assume AWS Role (Dev Account)
+        with:
+          command: install --dev
+      # Deployment to Development/Sandbox AWS Account
+      - name: Assume AWS Role (Development Account)
         uses: aws-actions/configure-aws-credentials@v1
+        if: github.ref == 'refs/heads/develop'
         with:
           aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::035458030717:role/SceptreBuildAccessRole
           role-duration-seconds: 1200
-      - name: Deploy 'dev' and 'prod' Stack Groups to Dev Account
-        run: |
-          pipenv shell
-          sceptre launch dev --yes
-          sceptre launch prod --yes
+      - name: Deploy 'dev' Stack Group to AWS Dev Account
+        uses: VaultVulp/action-pipenv@v2.0.1
+        if: github.ref == 'refs/heads/develop'
+        with:
+          command: run sceptre launch dev --yes
 
       # Commented out until the AWS account becomes available. Track this PR:
       # https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/135
 
-      # - name: Assume AWS Role (Prod Account)
+      # Deployment to Production AWS Account
+      # - name: Assume AWS Role (Production Account)
       #   uses: aws-actions/configure-aws-credentials@v1
       #   if: github.ref == 'refs/heads/main'
       #   with:
@@ -69,8 +71,8 @@ jobs:
       #     aws-region: us-east-1
       #     role-to-assume: arn:aws:iam::0123456789:role/SceptreBuildAccessRole
       #     role-duration-seconds: 1200
-      # - name: Deploy 'prod' Stack Group to Prod Account
+      # - name: Deploy 'prod' Stack Group to AWSProd Account
+      #   uses: VaultVulp/action-pipenv@v2.0.1
       #   if: github.ref == 'refs/heads/main'
-      #   run: |
-      #     pipenv shell
-      #     sceptre launch prod --yes
+      #   with:
+      #     command: run sceptre launch prod --yes

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -15,20 +15,6 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.2
 
-  # This job is commented out because 'sceptre validate'
-  # doesn't handle hooks and fails with remote templates
-  # sceptre-validate:
-  #   name: Validate CloudFormation templates using sceptre
-  #   runs-on: ubuntu-latest
-  #   needs: pre-commit
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v2
-  #     - name: Validate 'prod' templates
-  #       uses: Rurquhart/sceptre-action@v1.0
-  #       with:
-  #         sceptre_subcommand: validate prod
-
   sceptre-deploy:
     name: Deploy CloudFormation templates using sceptre
     runs-on: ubuntu-latest

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: '*'
   push:
-    branches: [main]
+    branches: [prod]
 
 jobs:
 

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -1,0 +1,68 @@
+name: aws-deploy
+
+on:
+  pull_request:
+    branches: '*'
+  push:
+    branches: [main, develop]
+
+jobs:
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0
+
+  sceptre-deploy:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install pipenv
+        run: |
+          pip install pipenv
+      - name: Cache Pipenv virtualenv
+        uses: actions/cache@v2
+        id: pipenv-cache
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-v2-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pipenv-v2-
+      - name: Install Dependencies
+        if: steps.pipenv-cache.outputs.cache-hit != 'true'
+        env:
+          PIPENV_NOSPIN: 'true'
+          WORKON_HOME: ~/.local/share/virtualenvs
+          PIPENV_CACHE_DIR: ~/.local/share/pipcache
+        run: pipenv install --dev
+      - name: Login as AWS Service User (Under Dev Account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Deploy both 'dev' and 'prod' stack groups to 'dev' account using sceptre
+        run: |
+          sceptre launch dev --yes
+          sceptre launch prod --yes
+      # - name: Assume AWS Role (Prod Account)
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   if: ${{ github.ref == 'refs/heads/main' }}
+      #   with:
+      #     aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
+      #     aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
+      #     aws-region: us-east-1
+      #     role-to-assume: arn:aws:iam::0987654321:role/NextflowWorkflows-CIServiceRole
+      #     role-duration-seconds: 1200
+      # - name: Deploy both 'prod' stack groups to 'prod' account using sceptre
+      #   if: ${{ github.ref == 'refs/heads/main' }}
+      #   run: |
+      #     sceptre launch prod --yes

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -15,22 +15,24 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.2
 
-  sceptre-validate:
-    name: Validate CloudFormation templates using sceptre
-    runs-on: ubuntu-latest
-    needs: pre-commit
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Validate 'prod' templates
-        uses: Rurquhart/sceptre-action@v1.0
-        with:
-          sceptre_subcommand: validate prod
+  # This job is commented out because 'sceptre validate'
+  # doesn't handle hooks and fails with remote templates
+  # sceptre-validate:
+  #   name: Validate CloudFormation templates using sceptre
+  #   runs-on: ubuntu-latest
+  #   needs: pre-commit
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v2
+  #     - name: Validate 'prod' templates
+  #       uses: Rurquhart/sceptre-action@v1.0
+  #       with:
+  #         sceptre_subcommand: validate prod
 
   sceptre-deploy:
     name: Deploy CloudFormation templates using sceptre
     runs-on: ubuntu-latest
-    needs: sceptre-validate
+    needs: pre-commit
     if: github.ref == 'refs/heads/prod'
     steps:
       - name: Checkout repository

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0
+      - uses: pre-commit/action@v2.0.2
 
   sceptre-validate:
     name: Validate CloudFormation templates using sceptre

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -1,4 +1,4 @@
-name: Validate and Deploy CloudFormation Templates
+name: aws-deploy
 
 on: push
 

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: '*'
   push:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
 
@@ -42,37 +42,13 @@ jobs:
           PIPENV_CACHE_DIR: ~/.local/share/pipcache
         with:
           command: install --dev
-      # Deployment to Development/Sandbox AWS Account
-      - name: Assume AWS Role (Development Account)
+      - name: Login Using CI Service User
         uses: aws-actions/configure-aws-credentials@v1
-        if: github.ref == 'refs/heads/develop'
         with:
-          aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.NEXTFLOW_PROD_CI_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.NEXTFLOW_PROD_CI_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::035458030717:role/SceptreBuildAccessRole
-          role-duration-seconds: 1200
-      - name: Deploy 'dev' Stack Group to AWS Dev Account
+      - name: Deploy to AWS Account
         uses: VaultVulp/action-pipenv@v2.0.1
-        if: github.ref == 'refs/heads/develop'
         with:
-          command: run sceptre launch dev --yes
-
-      # Commented out until the AWS account becomes available. Track this PR:
-      # https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/135
-
-      # Deployment to Production AWS Account
-      # - name: Assume AWS Role (Production Account)
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   if: github.ref == 'refs/heads/main'
-      #   with:
-      #     aws-access-key-id: ${{ secrets.CI_SERVICE_USER_ACCESS_KEY }}
-      #     aws-secret-access-key: ${{ secrets.CI_SERVICE_USER_SECRET_ACCESS_KEY }}
-      #     aws-region: us-east-1
-      #     role-to-assume: arn:aws:iam::0123456789:role/SceptreBuildAccessRole
-      #     role-duration-seconds: 1200
-      # - name: Deploy 'prod' Stack Group to AWSProd Account
-      #   uses: VaultVulp/action-pipenv@v2.0.1
-      #   if: github.ref == 'refs/heads/main'
-      #   with:
-      #     command: run sceptre launch prod --yes
+          command: run sceptre launch prod --yes

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ name = "pypi"
 
 [packages]
 sceptre = "*"
-sceptre-ssm-resolver = "*"
 
 [dev-packages]
 pre-commit = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "017fc883e7d8c764fd43ba9e1ea1e468675a887360b46719f082985fdbd0cdb7"
+            "sha256": "edfa8ba707955c835f0bfbe7a060533e3890682a4b54eebff38b241e70fc2d18"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:070c1c4fb75cb3d599e2eb520a50d8e763080f6c06d9de77e9773c36442f23e9",
-                "sha256:5dee15bf961ea584d681fae42c50034c839717e7454c3da90cb57a6c52e97532"
+                "sha256:5d62261ceb8e5b8fd4df1b91464a9000550d4caa454241794fa126c6e04d5b69",
+                "sha256:f7447d84c3e1381bb3cc61ceb360dab47e91ebd133725dbd6d98946f11e234d3"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.17.46"
+            "version": "==1.17.50"
         },
         "botocore": {
             "hashes": [
-                "sha256:50bbc3e9341c7daa8219db98c38f26012a151ca88fa260148e5bf3adcbcb9541",
-                "sha256:8cd22cd9dd3852c58dad714950b3fb62316d73c18c4eaf90eda1c677ab5e379b"
+                "sha256:a621a4bf60a1197c7ebd8ed0badac8282e36e0cee7241831a099200983ff7c49",
+                "sha256:f6c2bfae21eaa4e4f75fc5f48b22b16831356755bfb58516219ee11d74070220"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.46"
+            "version": "==1.20.50"
         },
         "click": {
             "hashes": [
@@ -49,11 +49,11 @@
         },
         "decorator": {
             "hashes": [
-                "sha256:acda948ffcfe4bd0c4a57834b74ad968b91925b8201b740ca9d46fb8c5c618ce",
-                "sha256:b7157d62ea3c2c0c57b81a05e4569853e976a3dda5dd7a1cb86be78978c3c5f8"
+                "sha256:d9f2d2863183a3c0df05f4b786f2e6b8752c093b3547a558f287bf3022fd2bf4",
+                "sha256:f2e71efb39412bfd23d878e896a51b07744f2e2250b2e87d158e76828c5ae202"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==5.0.5"
+            "version": "==5.0.6"
         },
         "jinja2": {
             "hashes": [
@@ -208,14 +208,6 @@
             "index": "pypi",
             "version": "==2.4.0"
         },
-        "sceptre-ssm-resolver": {
-            "hashes": [
-                "sha256:ac83ebed961bf65336c45c7c286fa1260744f172f2a4e136aea55608c1a8a09f",
-                "sha256:c51f8cad2a2cd7ab971032238f17d3114f2103bd3b92f9658acc07acdf08f717"
-            ],
-            "index": "pypi",
-            "version": "==1.1.0"
-        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
@@ -273,18 +265,18 @@
         },
         "identify": {
             "hashes": [
-                "sha256:43cb1965e84cdd247e875dec6d13332ef5be355ddc16776396d98089b9053d87",
-                "sha256:c7c0f590526008911ccc5ceee6ed7b085cbc92f7b6591d0ee5913a130ad64034"
+                "sha256:398cb92a7599da0b433c65301a1b62b9b1f4bb8248719b84736af6c0b22289d6",
+                "sha256:4537474817e0bbb8cea3e5b7504b7de6d44e3f169a90846cbc6adb0fc8294502"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==2.2.2"
+            "version": "==2.2.3"
         },
         "nodeenv": {
             "hashes": [
-                "sha256:5304d424c529c997bc888453aeaa6362d242b6b4631e90f3d4bf1b290f1c84a9",
-                "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"
+                "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b",
+                "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"
             ],
-            "version": "==1.5.0"
+            "version": "==1.6.0"
         },
         "pre-commit": {
             "hashes": [


### PR DESCRIPTION
I'm not sure what's the best way of testing these CI workflows other than reviewing them and making sure they behave as expected once merged. 

I've opted for a setup where we have two stack groups: `dev` and `prod`. The `dev` stacks will be deployed to the `workflows-nextflow-dev` account whereas the `prod` stacks will be deployed to the `workflows-nextflow-dev` and `workflows-nextflow-prod` accounts. Another pattern I noticed [here](https://github.com/Sage-Bionetworks/iAtlas-infra/tree/staging/config) is to have `dev`, `prod`, and `common`. 

You can ignore the change affecting the `CODEOWNERS` file. I just removed the extra line at the end of the file to satisfy the pre-commit test. 