### PR TITLE
Create S3 bucket for storing CloudFormation templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore anything downloaded by sceptre hooks during testing
+/templates/remote/

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,2 +1,3 @@
-project_code: aws-nextflow-workflows
+project_code: aws-workflows-nextflow-infra
 region: us-east-1
+admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,4 @@
 project_code: aws-workflows-nextflow-infra
-region: us-east-1
-admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
+profile: {{ var.profile | default("default") }}
+region: {{ var.region | default("us-east-1") }}
+aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.3/templates

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,4 @@
 project_code: aws-workflows-nextflow-infra
 profile: {{ var.profile | default("default") }}
 region: {{ var.region | default("us-east-1") }}
-aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.3/templates
+aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra

--- a/config/prod/s3-cfn-templates.yaml
+++ b/config/prod/s3-cfn-templates.yaml
@@ -1,0 +1,9 @@
+template_path: "remote/S3/public-bucket.yaml"
+stack_name: "cloudformation-templates"
+stack_tags:
+  Department: "CompOnc"
+  Project: "imCORE"
+  OwnerEmail: "bruno.grande@sagebase.org"
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/master/S3/public-bucket.yaml --create-dirs -o templates/remote/S3/public-bucket.yaml"

--- a/config/prod/s3-cfn-templates.yaml
+++ b/config/prod/s3-cfn-templates.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "bruno.grande@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/master/S3/public-bucket.yaml --create-dirs -o templates/remote/S3/public-bucket.yaml"
+    - !cmd "curl {{stack_group_config.aws_infra_templates_root_url}}/S3/public-bucket.yaml --create-dirs -o templates/remote/S3/public-bucket.yaml"

--- a/config/prod/s3-cfn-templates.yaml
+++ b/config/prod/s3-cfn-templates.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "bruno.grande@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/S3/public-bucket.yaml -N -P templates/remote"
+    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.3/templates/S3/public-bucket.yaml -N -P templates/remote"

--- a/config/prod/s3-cfn-templates.yaml
+++ b/config/prod/s3-cfn-templates.yaml
@@ -1,4 +1,4 @@
-template_path: "remote/S3/public-bucket.yaml"
+template_path: "remote/public-bucket.yaml"
 stack_name: "cloudformation-templates"
 stack_tags:
   Department: "CompOnc"
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "bruno.grande@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl {{stack_group_config.aws_infra_templates_root_url}}/S3/public-bucket.yaml --create-dirs -o templates/remote/S3/public-bucket.yaml"
+    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/S3/public-bucket.yaml -N -P templates/remote"


### PR DESCRIPTION
For now, the only use case is for storing the templates from the [aws-genomics-workflows-library](https://github.com/Sage-Bionetworks-Workflows/aws-genomics-workflows-library) repository. 

@zaro0508: Is there a reason why you deploy templates to an S3 bucket instead of downloading from GitHub directly in the sceptre pre-hooks? If you think the S3 deployment is essential, then your review of this PR would be appreciated. 