### PR TITLE
Add NextFlow service account policy and user

### DIFF
--- a/config/prod/nextflow-forge-iam-policy.yaml
+++ b/config/prod/nextflow-forge-iam-policy.yaml
@@ -1,0 +1,2 @@
+template_path: nextflow-forge-iam-policy.yaml
+stack_name: nextflow-forge-iam-policy

--- a/config/prod/nextflow-forge-service-user.yaml
+++ b/config/prod/nextflow-forge-service-user.yaml
@@ -1,0 +1,7 @@
+template_path: "nextflow-forge-service-user.yaml"
+stack_name: "nextflow-forge-service-user"
+dependencies:
+  - prod/nextflow-forge-iam-policy.yaml
+parameters:
+  ManagedPolicyArns:
+    - !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn

--- a/templates/nextflow-forge-iam-policy.yaml
+++ b/templates/nextflow-forge-iam-policy.yaml
@@ -1,0 +1,53 @@
+Description: Policy for NextFlow Forge service user
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  NextFlowForgePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Action:
+            - ssm:GetParameters
+            - iam:CreateInstanceProfile
+            - iam:DeleteInstanceProfile
+            - iam:GetRole
+            - iam:RemoveRoleFromInstanceProfile
+            - iam:CreateRole
+            - iam:DeleteRole
+            - iam:AttachRolePolicy
+            - iam:PutRolePolicy
+            - iam:AddRoleToInstanceProfile
+            - iam:PassRole
+            - iam:DetachRolePolicy
+            - iam:ListAttachedRolePolicies
+            - iam:DeleteRolePolicy
+            - iam:ListRolePolicies
+            - batch:CreateComputeEnvironment
+            - batch:DescribeComputeEnvironments
+            - batch:CreateJobQueue
+            - batch:DescribeJobQueues
+            - batch:UpdateComputeEnvironment
+            - batch:DeleteComputeEnvironment
+            - batch:UpdateJobQueue
+            - batch:DeleteJobQueue
+            - fsx:DeleteFileSystem
+            - fsx:DescribeFileSystems
+            - fsx:CreateFileSystem
+            - ec2:DescribeSecurityGroups
+            - ec2:DescribeAccountAttributes
+            - ec2:DescribeSubnets
+            - ec2:DescribeLaunchTemplates
+            - ec2:DescribeLaunchTemplateVersions
+            - ec2:CreateLaunchTemplate
+            - ec2:DeleteLaunchTemplate
+            - ec2:DescribeKeyPairs
+            - ec2:DescribeVpcs
+            - ec2:DescribeInstanceTypeOfferings
+          Resource: "*"
+Outputs:
+  NextFlowForgePolicyArn:
+    Value: !Ref NextFlowForgePolicy
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-NextFlowForgePolicyArn'

--- a/templates/nextflow-forge-service-user.yaml
+++ b/templates/nextflow-forge-service-user.yaml
@@ -1,0 +1,36 @@
+Description: Setup an AWS service account and role
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  ManagedPolicyArns:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >-
+      A list of managed policies for the role.
+      Example:
+        ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", "arn:aws:iam::1111111111:policy/MY-EXISTING-POLICY"]
+Resources:
+  ServiceUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      ManagedPolicyArns: !Ref ManagedPolicyArns
+  ServiceUserAccessKey:
+    Type: 'AWS::IAM::AccessKey'
+    Properties:
+      UserName: !Ref ServiceUser
+Outputs:
+  ServiceUser:
+    Value: !Ref ServiceUser
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUser'
+  ServiceUserArn:
+    Value: !GetAtt ServiceUser.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUserArn'
+  ServiceUserAccessKey:
+    Value: !Ref ServiceUserAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUserAccessKey'
+  ServiceUserSecretAccessKey:
+    Value: !GetAtt ServiceUserAccessKey.SecretAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceUserSecretAccessKey'


### PR DESCRIPTION
This PR adds a policy and service account user for NextFlow to provision batch resources in our AWS account through their [Forge option](https://help.tower.nf/docs/compute-envs/aws-batch/#forge).