### PR TITLE
Fix CICD refactor issues

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -22,10 +22,10 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.NEXTFLOW_PROD_CI_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.NEXTFLOW_PROD_CI_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.NEXTFLOW_DEV_CI_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.NEXTFLOW_DEV_CI_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::728882028485:role/workflows-nextflow-ci-service-account-ServiceRole-CTLXKJIOCRO4
+          role-to-assume: arn:aws:iam::035458030717:role/workflows-nextflow-ci-service-account-ServiceRole-188LV3KMGCYBL
           role-duration-seconds: 1200
       - name: Deploy common configuration
         uses: Sage-Bionetworks/sceptre-action@v1.1
@@ -37,3 +37,16 @@ jobs:
         with:
           sceptre_version: 2.4.0
           sceptre_subcommand: launch --yes develop
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.NEXTFLOW_PROD_CI_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.NEXTFLOW_PROD_CI_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::728882028485:role/workflows-nextflow-ci-service-account-ServiceRole-CTLXKJIOCRO4
+          role-duration-seconds: 1200
+      - name: Deploy common configuration
+        uses: Sage-Bionetworks/sceptre-action@v1.1
+        with:
+          sceptre_version: 2.4.0
+          sceptre_subcommand: launch --yes common

--- a/config/common/nextflow-forge-service-user.yaml
+++ b/config/common/nextflow-forge-service-user.yaml
@@ -1,8 +1,8 @@
 template_path: "nextflow-forge-service-user.yaml"
 stack_name: "nextflow-forge-service-user"
 dependencies:
-  - prod/nextflow-forge-iam-policy.yaml
-  - prod/nextflow-launch-iam-policy.yaml
+  - common/nextflow-forge-iam-policy.yaml
+  - common/nextflow-launch-iam-policy.yaml
 parameters:
   ManagedPolicyArns:
     - !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn


### PR DESCRIPTION
1. Fix reference to dependencies that were moved from prod to common
2. Use appropriate service role for each AWS account. Additional secrets have already been added to the organization.