### PR TITLE
WORKFLOWS-21: Add ECS cluster stack

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.0.1
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.17.0
+    rev: v1.26.1
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
@@ -14,6 +14,6 @@ repos:
       - id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.6
+    rev: v1.1.10
     hooks:
       - id: remove-tabs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.29.0
+    rev: v0.52.0
     hooks:
       - id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -69,7 +69,6 @@
                 "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760",
                 "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==4.4.2"
         },
         "distlib": {
@@ -107,7 +106,7 @@
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.0"
         },
         "markupsafe": {
@@ -185,7 +184,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.4.7"
         },
         "python-dateutil": {
@@ -193,7 +192,7 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.1"
         },
         "pyyaml": {
@@ -259,7 +258,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "toml": {
@@ -267,7 +266,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "urllib3": {

--- a/config/develop/nextflow-ecs-capacity.yaml
+++ b/config/develop/nextflow-ecs-capacity.yaml
@@ -1,0 +1,13 @@
+template_path: nextflow-ecs-capacity.yaml
+stack_name: nextflow-ecs-capacity
+dependencies:
+  - develop/nextflow-ecs-cluster.yaml
+parameters:
+  EcsClusterName: !stack_output_external nextflow-ecs-cluster::EcsClusterName
+  AutoScalingGroupArn: !rcmd >-
+    aws autoscaling describe-auto-scaling-groups
+    | jq -r '.AutoScalingGroups | .[] | select(.AutoScalingGroupName | startswith("nextflow-ecs-cluster-EcsAutoScalingGroup")) | .AutoScalingGroupARN'
+stack_tags:
+  Department: IBC
+  Project: Infrastructure
+  OwnerEmail: nextflow-admins@sagebase.org

--- a/config/develop/nextflow-ecs-capacity.yaml
+++ b/config/develop/nextflow-ecs-capacity.yaml
@@ -4,6 +4,8 @@ dependencies:
   - develop/nextflow-ecs-cluster.yaml
 parameters:
   EcsClusterName: !stack_output_external nextflow-ecs-cluster::EcsClusterName
+  # rcmd is used to derive this parameter because the Autoscaling ARN is
+  # accessible through neither Ref nor GetAtt.
   AutoScalingGroupArn: !rcmd >-
     aws autoscaling describe-auto-scaling-groups
     | jq -r '.AutoScalingGroups | .[] | select(.AutoScalingGroupName | startswith("nextflow-ecs-cluster-EcsAutoScalingGroup")) | .AutoScalingGroupARN'

--- a/config/develop/nextflow-ecs-cluster.yaml
+++ b/config/develop/nextflow-ecs-cluster.yaml
@@ -5,9 +5,7 @@ dependencies:
 parameters:
   VpcId: !stack_output_external nextflow-vpc::VPCId
   SubnetIds:
-    - !stack_output_external nextflow-vpc::PrivateSubnet
-    - !stack_output_external nextflow-vpc::PrivateSubnet1
-    - !stack_output_external nextflow-vpc::PrivateSubnet2
+    - !stack_output_external nextflow-vpc::PublicSubnet
   SecurityIngressFromPort: '80'
   SecurityIngressToPort: '8080'
 stack_tags:

--- a/config/develop/nextflow-ecs-cluster.yaml
+++ b/config/develop/nextflow-ecs-cluster.yaml
@@ -1,0 +1,16 @@
+template_path: nextflow-ecs-cluster.yaml
+stack_name: nextflow-ecs-cluster
+dependencies:
+  - develop/nextflow-vpc.yaml
+parameters:
+  VpcId: !stack_output_external nextflow-vpc::VPCId
+  SubnetIds:
+    - !stack_output_external nextflow-vpc::PrivateSubnet
+    - !stack_output_external nextflow-vpc::PrivateSubnet1
+    - !stack_output_external nextflow-vpc::PrivateSubnet2
+  SecurityIngressFromPort: '80'
+  SecurityIngressToPort: '8080'
+stack_tags:
+  Department: IBC
+  Project: Infrastructure
+  OwnerEmail: nextflow-admins@sagebase.org

--- a/config/develop/nextflow-vpc.yaml
+++ b/config/develop/nextflow-vpc.yaml
@@ -5,4 +5,5 @@ parameters:
   VpcSubnetPrefix: "172.21"
 hooks:
   before_launch:
-    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.2.5/templates/VPC/vpc-20-private.yaml -O templates/remote/vpc-20-private.yaml"
+    # Need someone to create a new tag on aws-infra so tthat I can use a tag rather than an SHA
+    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/f169dffb7649f83e6bea647be9b64078112401cc/templates/VPC/vpc-20-private.yaml -O templates/remote/vpc-20-private.yaml"

--- a/templates/nextflow-ecs-capacity.yaml
+++ b/templates/nextflow-ecs-capacity.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: ECS Cluster Capacity Provider
+
+Parameters:
+
+  AutoScalingGroupArn:
+    Type: String
+
+  EcsClusterName:
+    Type: String
+
+Resources:
+
+  EcsCapacityProvider:
+    Type: AWS::ECS::CapacityProvider
+    Properties:
+      AutoScalingGroupProvider:
+        AutoScalingGroupArn: !Ref AutoScalingGroupArn
+
+  EcsClusterCapacityProviderAssociation:
+    Type: AWS::ECS::ClusterCapacityProviderAssociations
+    Properties:
+      CapacityProviders:
+        - !Ref EcsCapacityProvider
+      Cluster: !Ref EcsClusterName
+      DefaultCapacityProviderStrategy:
+        - CapacityProvider: !Ref EcsCapacityProvider
+
+Outputs:
+
+  EcsCapacityProviderName:
+    Value: !Ref EcsCapacityProvider
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsCapacityProvider'

--- a/templates/nextflow-ecs-capacity.yaml
+++ b/templates/nextflow-ecs-capacity.yaml
@@ -36,4 +36,4 @@ Outputs:
   EcsCapacityProviderName:
     Value: !Ref EcsCapacityProvider
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsCapacityProvider'
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsCapacityProviderName'

--- a/templates/nextflow-ecs-capacity.yaml
+++ b/templates/nextflow-ecs-capacity.yaml
@@ -6,9 +6,13 @@ Parameters:
 
   AutoScalingGroupArn:
     Type: String
+    Description: >
+      The ARN of the autoscaling group that will be used
+      as a capacity provider to an ECS cluster.
 
   EcsClusterName:
     Type: String
+    Description: The ECS cluster to associate with the capacity provider.
 
 Resources:
 

--- a/templates/nextflow-ecs-cluster.yaml
+++ b/templates/nextflow-ecs-cluster.yaml
@@ -1,0 +1,184 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: ECS Cluster for NextFlow Tower
+
+Parameters:
+
+  EcsClusterName:
+    Type: String
+    Description: >
+      Specifies the ECS Cluster Name with which the resources would be
+      associated
+    Default: 'nf-tower'
+
+  EcsAmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Description: Specifies the AMI ID for your container instances.
+    Default: '/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id'
+
+  EcsInstanceType:
+    Type: String
+    Description: Specifies the EC2 instance type for your container instances.
+    Default: 'c4.2xlarge'
+
+  VpcId:
+    Description: ID of VPC
+    Type: AWS::EC2::VPC::Id
+
+  SubnetIds:
+    Type: CommaDelimitedList
+    Description: >
+      Specifies the Comma separated list of existing VPC Subnet
+      Ids where ECS instances will run.
+
+  AutoscalingGroupMaxSize:
+    Type: Number
+    Description: >
+      Specifies the number of instances to launch and register to the cluster.
+      Defaults to 1.
+    Default: '1'
+
+  SecurityIngressFromPort:
+    Type: Number
+    Description: >
+      Optional - Specifies the Start of Security Group port to open on
+      ECS instances - defaults to port 0
+    Default: '0'
+
+  SecurityIngressToPort:
+    Type: Number
+    Description: >
+      Optional - Specifies the End of Security Group port to open on ECS
+      instances - defaults to port 65535
+    Default: '65535'
+
+  SecurityIngressCidrIp:
+    Type: String
+    Description: >
+      Optional - Specifies the CIDR/IP range for Security Ports - defaults
+      to 0.0.0.0/0
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Default: '0.0.0.0/0'
+
+  RootEbsVolumeSize:
+    Type: Number
+    Description: Optional - Specifies the Size in GBs of the root EBS volume
+    Default: 30
+
+  EbsVolumeType:
+    Type: String
+    Description: Specifies the Type of (Amazon EBS) volume.
+    AllowedValues:
+      - io1
+      - gp2
+      - sc1
+      - st1
+      - standard
+    ConstraintDescription: Must be a valid EC2 volume type.
+    Default: 'gp2'
+
+  RootDeviceName:
+    Type: String
+    Description: Optional - Specifies the device mapping for the root EBS volume.
+    Default: '/dev/xvda'
+
+
+Resources:
+
+  EcsCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Ref EcsClusterName
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+
+  EcsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+              - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
+  EcsInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref EcsRole
+
+  EcsSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: ECS Allowed Ports
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref SecurityIngressFromPort
+          ToPort: !Ref SecurityIngressToPort
+          CidrIp: !Ref SecurityIngressCidrIp
+
+  EcsLaunchConfiguration:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      ImageId: !Ref EcsAmiId
+      InstanceType: !Ref EcsInstanceType
+      AssociatePublicIpAddress: true
+      IamInstanceProfile: !Ref EcsInstanceProfile
+      SecurityGroups:
+        - !Ref EcsSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: !Ref RootDeviceName
+          Ebs:
+            VolumeSize: !Ref RootEbsVolumeSize
+            VolumeType: !Ref EbsVolumeType
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          echo ECS_CLUSTER=${EcsClusterName} >> /etc/ecs/ecs.config
+          echo ECS_BACKEND_HOST= >> /etc/ecs/ecs.config
+
+  EcsAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      VPCZoneIdentifier: !Ref SubnetIds
+      LaunchConfigurationName: !Ref EcsLaunchConfiguration
+      MinSize: '0'
+      MaxSize: !Ref AutoscalingGroupMaxSize
+      DesiredCapacity: !Ref AutoscalingGroupMaxSize
+
+Outputs:
+
+  EcsClusterName:
+    Value: !Ref EcsCluster
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsClusterName'
+
+  EcsRoleArn:
+    Value: !GetAtt EcsRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsRoleArn'
+
+  EcsSecurityGroupId:
+    Value: !Ref EcsSecurityGroup
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsSecurityGroupId'
+
+  EcsLaunchConfigurationName:
+    Value: !Ref EcsLaunchConfiguration
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsLaunchConfiguration'
+
+  EcsAutoScalingGroupName:
+    Value: !Ref EcsAutoScalingGroup
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsAutoScalingGroupName'


### PR DESCRIPTION
[WORKFLOWS-21](https://sagebionetworks.jira.com/browse/WORKFLOWS-21)
This creates an ECS cluster that has a single instance in it.

One disadvantage of doing this is that we can't export the PublicIp attribute as we would if this were configured as `AWS::EC2::Instance`, and that is required for the [ECS task stack](https://sagebionetworks.jira.com/browse/WORKFLOWS-22). However, I will probably be able to use `!rcmd` to get the PublicIP for that parameter.

PR depends on #19 and on https://github.com/Sage-Bionetworks/aws-infra/pull/315