### PR TITLE
Update IAM Forge Policy

### DIFF
--- a/templates/nextflow-forge-iam-policy.yaml
+++ b/templates/nextflow-forge-iam-policy.yaml
@@ -45,6 +45,14 @@ Resources:
             - ec2:DescribeKeyPairs
             - ec2:DescribeVpcs
             - ec2:DescribeInstanceTypeOfferings
+            - elasticfilesystem:DescribeMountTargets
+            - elasticfilesystem:CreateMountTarget
+            - elasticfilesystem:CreateFileSystem
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DeleteMountTarget
+            - elasticfilesystem:DeleteFileSystem
+            - elasticfilesystem:UpdateFileSystem
+            - elasticfilesystem:PutLifecycleConfiguration
           Resource: "*"
 Outputs:
   NextFlowForgePolicyArn:

--- a/templates/nextflow-forge-iam-policy.yaml
+++ b/templates/nextflow-forge-iam-policy.yaml
@@ -52,7 +52,7 @@ Resources:
             - elasticfilesystem:DeleteMountTarget
             - elasticfilesystem:DeleteFileSystem
             - elasticfilesystem:UpdateFileSystem
-            - elasticfilesystem:PutLifecycleConfiguration
+            - elasticfilesystem:PutLifecycleConfiguration 
           Resource: "*"
 Outputs:
   NextFlowForgePolicyArn:


### PR DESCRIPTION
Update IAM forge policy to allow for EFS permissions, based on [Seqera's Forge Policy Update](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json)