### PR TITLE
Update Nextflow IAM Forge Policy

### DIFF
--- a/templates/nextflow-forge-iam-policy.yaml
+++ b/templates/nextflow-forge-iam-policy.yaml
@@ -45,6 +45,14 @@ Resources:
             - ec2:DescribeKeyPairs
             - ec2:DescribeVpcs
             - ec2:DescribeInstanceTypeOfferings
+            - elasticfilesystem:DescribeMountTargets
+            - elasticfilesystem:CreateMountTarget
+            - elasticfilesystem:CreateFileSystem
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DeleteMountTarget
+            - elasticfilesystem:DeleteFileSystem
+            - elasticfilesystem:UpdateFileSystem
+            - elasticfilesystem:PutLifecycleConfiguration
           Resource: "*"
 Outputs:
   NextFlowForgePolicyArn:


### PR DESCRIPTION
Update nextflow-forge-iam-policy to reflect [Seqera's updated forge policy](https://github.com/seqeralabs/nf-tower-aws/blob/master/forge/forge-policy.json), which allows for EFS permissions