### PR TITLE
Add stack that produces SMTP credentials

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@Sage-Bionetworks-Workflows/aws-infra
+* @Sage-Bionetworks-Workflows/aws-infra

--- a/config/common/smtp-credentials.yaml
+++ b/config/common/smtp-credentials.yaml
@@ -1,0 +1,9 @@
+template_path: smtp-credentials.yaml
+stack_name: smtp-credentials
+parameters:
+  IamAccessKeyVersion: '1'
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
+stack_tags:
+  Department: IBC
+  Project: Infrastructure
+  OwnerEmail: nextflow-admins@sagebase.org

--- a/templates/smtp-credentials.yaml
+++ b/templates/smtp-credentials.yaml
@@ -24,6 +24,13 @@ Parameters:
       URL of S3 bucket where templates used for nested stacks are deployed
     ConstraintDescription: Must be a valid S3 HTTP URL
 
+Mappings:
+  Accounts:
+    "035458030717":
+      AdminRole: "arn:aws:iam::035458030717:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_580e9f32ac55c4e7"
+    "728882028485":
+      AdminRole: "arn:aws:iam::728882028485:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_3a9d61d0884be260"
+
 Resources:
 
   SmtpUserGroup:
@@ -117,11 +124,13 @@ Resources:
           - - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
             - !ImportValue
               'Fn::Sub': '${AWS::Region}-workflows-nextflow-ci-service-account-ServiceUserArn'
+            - !FindInMap [Accounts, !Ref AWS::AccountId, AdminRole]
         UserPrincipalArns: !Join
           - ','
           - - !ImportValue
               'Fn::Sub': '${AWS::Region}-workflows-nextflow-ci-service-account-ServiceUserArn'
             - !GetAtt SmtpLambdaExecutionRole.Arn
+            - !FindInMap [Accounts, !Ref AWS::AccountId, AdminRole]
 
   SmtpLambdaLogGroup:
     Type: AWS::Logs::LogGroup

--- a/templates/smtp-credentials.yaml
+++ b/templates/smtp-credentials.yaml
@@ -1,0 +1,272 @@
+# Derived from a template created by Travis Samuel
+# MIT License https://github.com/tsamuel33/aws-smtp-credentials/blob/main/LICENSE
+# Template repository https://github.com/tsamuel33/aws-smtp-credentials
+
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template creates a custom SMTP resource that stores the SMTP
+  credentials in Parameter Store under the names "smtp-username" and
+  "smtp-password".
+
+Parameters:
+
+  IamAccessKeyVersion:
+    Type: Number
+    Default: 1
+    Description: >-
+      Version number of the AWS access keys.
+      Increment this number to rotate the keys.
+    MinValue: 1
+
+  TemplateRootUrl:
+    Type: String
+    Description: >-
+      URL of S3 bucket where templates used for nested stacks are deployed
+    ConstraintDescription: Must be a valid S3 HTTP URL
+
+Resources:
+
+  SmtpUserGroup:
+    Type: AWS::IAM::Group
+    Properties:
+      GroupName: SMTPUserGroup
+
+  SmtpUser:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: SMTPUser
+      Groups:
+        - !Ref SmtpUserGroup
+
+  SmtpUserPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: SMTPUserPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: ses:SendRawEmail
+            Resource: '*'
+      Groups:
+        - !Ref SmtpUserGroup
+
+  SmtpUserAccessKey:
+    Type: AWS::IAM::AccessKey
+    Properties:
+      Serial: !Ref IamAccessKeyVersion
+      Status: Active
+      UserName: !Ref SmtpUser
+
+  SmtpPassword:
+    Type: Custom::SmtpPassword
+    Properties:
+      ServiceToken: !GetAtt SmtpLambdaFunction.Arn
+      Key: !GetAtt SmtpUserAccessKey.SecretAccessKey
+      ParameterType: password
+
+  SmtpUsername:
+    Type: Custom::SmtpUsername
+    Properties:
+      ServiceToken: !GetAtt SmtpLambdaFunction.Arn
+      Key: !Ref SmtpUserAccessKey
+      ParameterType: username
+
+  SmtpLambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: SMTPLambdaExecutionRole
+      Description: Role assumed by Lambda to generate SMTP credentials
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: InlineSMTPLambdaExecutionRolePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+                - Effect: Allow
+                  Action:
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource:
+                    - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/SMTPCredentialsLambdaFunction"
+                    - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/SMTPCredentialsLambdaFunction:log-stream:*"
+                - Effect: Allow
+                  Action:
+                    - ssm:PutParameter
+                    - ssm:DeleteParameter
+                  Resource:
+                    - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/smtp-username"
+                    - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/smtp-password"
+
+  SmtpKeyStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub ${TemplateRootUrl}/aws-infra/v0.2.19/KMS/kms-key.yaml
+      TimeoutInMinutes: 5
+      Parameters:
+        AliasName: 'alias/smtp-credentials'
+        AdminPrincipalArns: !Join
+          - ','
+          - - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            - !ImportValue
+              'Fn::Sub': '${AWS::Region}-workflows-nextflow-ci-service-account-ServiceUserArn'
+        UserPrincipalArns: !Join
+          - ','
+          - - !ImportValue
+              'Fn::Sub': '${AWS::Region}-workflows-nextflow-ci-service-account-ServiceUserArn'
+            - !GetAtt SmtpLambdaExecutionRole.Arn
+
+  SmtpLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join [ "/", [/aws, lambda, SMTPCredentialsLambdaFunction]]
+
+  SmtpLambdaFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: SmtpLambdaLogGroup
+    Properties:
+      Description: Generates SMTP credentials and stores in Parameter Store
+      FunctionName: SMTPCredentialsLambdaFunction
+      Handler: index.lambda_handler
+      MemorySize: 128
+      Environment:
+        Variables:
+          KMS_KEY_ARN: !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${SmtpKeyStack.Outputs.Key}'
+      Role: !GetAtt SmtpLambdaExecutionRole.Arn
+      Runtime: python3.8
+      Timeout: 30
+      Code:
+        ZipFile: !Sub |
+          import hmac
+          import hashlib
+          import base64
+          import argparse
+          import boto3
+          from botocore.exceptions import ClientError
+          import json
+          import cfnresponse
+          import urllib3
+          import logging
+          import os
+
+          logging.basicConfig(level=logging.DEBUG)
+          log = logging.getLogger(__name__)
+          region = os.environ['AWS_REGION']
+          ssm = boto3.client('ssm', region_name=region)
+
+          SMTP_REGIONS = [
+              'us-east-2',       # US East (Ohio)
+              'us-east-1',       # US East (N. Virginia)
+              'us-west-2',       # US West (Oregon)
+              'ap-south-1',      # Asia Pacific (Mumbai)
+              'ap-northeast-2',  # Asia Pacific (Seoul)
+              'ap-southeast-1',  # Asia Pacific (Singapore)
+              'ap-southeast-2',  # Asia Pacific (Sydney)
+              'ap-northeast-1',  # Asia Pacific (Tokyo)
+              'ca-central-1',    # Canada (Central)
+              'eu-central-1',    # Europe (Frankfurt)
+              'eu-west-1',       # Europe (Ireland)
+              'eu-west-2',       # Europe (London)
+              'sa-east-1',       # South America (Sao Paulo)
+              'us-gov-west-1',   # AWS GovCloud (US)
+          ]
+
+          # These values are required to calculate the signature. Do not change them.
+          DATE = "11111111"
+          SERVICE = "ses"
+          MESSAGE = "SendRawEmail"
+          TERMINAL = "aws4_request"
+          VERSION = 0x04
+
+          def sign(key, msg):
+              return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
+
+          def calculate_key(secret_access_key, region):
+              if region not in SMTP_REGIONS:
+                  raise ValueError(f"The {region} Region doesn't have an SMTP endpoint.")
+
+              signature = sign(("AWS4" + secret_access_key).encode('utf-8'), DATE)
+              signature = sign(signature, region)
+              signature = sign(signature, SERVICE)
+              signature = sign(signature, TERMINAL)
+              signature = sign(signature, MESSAGE)
+              signature_and_version = bytes([VERSION]) + signature
+              smtp_password = base64.b64encode(signature_and_version)
+              return smtp_password.decode('utf-8')
+
+          def put_parameter(value,type):
+            try:
+              ssm.put_parameter(
+                        Name='smtp-'+type,
+                        Description='SMTP '+type+' for email communications',
+                        Value=value,
+                        Type='SecureString',
+                        KeyId=os.environ['KMS_KEY_ARN'],
+                        Overwrite=True,
+                        Tier='Standard'
+                    )
+              return True
+            except Exception as e:
+              print("Error putting parameter smtp-"+type+": "+str(e))
+              return False
+
+          def delete_smtp_credentials(type):
+            try:
+              ssm.delete_parameter(Name='smtp-'+type)
+              return True
+            except Exception as e:
+              print("Error deleting parameter smtp-"+type+": "+str(e))
+              return False
+
+
+          def lambda_handler(event, context):
+            log.debug('%s', event)
+            parameter_type = event['ResourceProperties']['ParameterType']
+            parameter_arn = "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/smtp-"+parameter_type
+            key = event['ResourceProperties']['Key']
+            proceed = "True"
+
+            if event['RequestType'] == 'Create':
+              if parameter_type == 'username':
+                proceed = put_parameter(key, parameter_type)
+              elif parameter_type == 'password':
+                pwd = calculate_key(key, region)
+                proceed = put_parameter(pwd, parameter_type)
+              reason = "Created SMTP "+parameter_type
+            elif event['RequestType'] == 'Update':
+              if parameter_type == 'username':
+                proceed = put_parameter(key, parameter_type)
+              elif parameter_type == 'password':
+                pwd = calculate_key(key, region)
+                proceed = put_parameter(pwd, parameter_type)
+              reason = "Updated SMTP "+parameter_type
+            elif event['RequestType'] == 'Delete':
+              proceed = delete_smtp_credentials(parameter_type)
+              reason = "Deleted SMTP "+parameter_type
+            else:
+              proceed = False
+              reason = "Operation %s is unsupported" % (event['RequestType'])
+
+            if proceed:
+              cfnresponse.send(event, context, cfnresponse.SUCCESS, {'Reason': reason}, parameter_arn)
+            else:
+              cfnresponse.send(event, context, cfnresponse.FAILED, {'Reason': reason}, parameter_arn)
+
+Outputs:
+
+  SmtpUserName:
+    Value: !Ref SmtpUser
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SmtpUserName'
+
+  SmtpUserArn:
+    Value: !GetAtt SmtpUser.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SmtpUserArn'


### PR DESCRIPTION
[WORKFLOWS-11](https://sagebionetworks.jira.com/browse/WORKFLOWS-11): NextFlow needs SMTP credentials set up so that Tower can send email.

This is adapated from [tsamuel33/aws-smtp-credentials](https://github.com/tsamuel33/aws-smtp-credentials).