### PR TITLE
KMS key for bootstrapping must be in same stack with Lambda

### DIFF
--- a/config/develop/nextflow-aurora-mysql.yaml
+++ b/config/develop/nextflow-aurora-mysql.yaml
@@ -1,14 +1,13 @@
 template_path: nextflow-aurora-mysql.yaml
 stack_name: nextflow-aurora-mysql
 dependencies:
-  - common/workflows-kms-key.yaml
   - develop/nextflow-vpc.yaml
 parameters:
   VpcID: !stack_output_external nextflow-vpc::VPCId
   SubnetIDs:
     - !stack_output_external nextflow-vpc::PrivateSubnet1
     - !stack_output_external nextflow-vpc::PrivateSubnet2
-  KmsKeyAlias: !stack_output_external workflows-infra-kms-key::Alias
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
 stack_tags:
   Department: IBC
   Project: Infrastructure

--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -47,10 +47,10 @@ Parameters:
     Type: String
     Default: ''
 
-  KmsKeyAlias:
-    Description: Optional. KMS key alias used to encrypt secrets stored in Secrets Manager.
+  TemplateRootUrl:
     Type: String
-    Default: 'alias/workflows-infra'
+    Description: URL of S3 bucket where templates are deployed
+    ConstraintDescription: Must be a valid S3 HTTP URL
 
 Mappings:
   ClusterSettings:
@@ -58,12 +58,38 @@ Mappings:
       version: 5.7.mysql_aurora.2.07.1
       engine: aurora-mysql
       family: aurora-mysql5.7
+  Accounts:
+    "035458030717":
+      AdminRole: "arn:aws:iam::035458030717:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_580e9f32ac55c4e7"
+    "728882028485":
+      AdminRole: "arn:aws:iam::728882028485:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_3a9d61d0884be260"
 
 Conditions:
   UseSnapshotTrue: !Not [!Equals [!Ref SnapshotName, '']]
   UseSnapshotFalse: !Equals [!Ref SnapshotName, '']
 
 Resources:
+
+  AuroraKeyStack:
+    Condition: UseSnapshotFalse
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub ${TemplateRootUrl}/aws-infra/v0.2.19/KMS/kms-key.yaml
+      TimeoutInMinutes: 5
+      Parameters:
+        AliasName: 'alias/nextflow-aurora-bootstrap-lambda'
+        AdminPrincipalArns: !Join
+          - ','
+          - - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            - !ImportValue
+              'Fn::Sub': '${AWS::Region}-workflows-nextflow-ci-service-account-ServiceRoleArn'
+            - !FindInMap [Accounts, !Ref AWS::AccountId, AdminRole]
+        UserPrincipalArns: !Join
+          - ','
+          - - !ImportValue
+              'Fn::Sub': '${AWS::Region}-workflows-nextflow-ci-service-account-ServiceRoleArn'
+            - !FindInMap [Accounts, !Ref AWS::AccountId, AdminRole]
+            - !GetAtt BootstrapLambdaRole.Arn
 
   AuroraMasterSecret:
     Condition: UseSnapshotFalse
@@ -76,7 +102,7 @@ Resources:
         GenerateStringKey: password
         ExcludeCharacters: '"@/\$`&'
         PasswordLength: 16
-      KmsKeyId: !Ref KmsKeyAlias
+      KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
 
   AuroraNextflowTowerDatabaseUserSecret:
     Condition: UseSnapshotFalse
@@ -89,7 +115,7 @@ Resources:
         GenerateStringKey: password
         ExcludeCharacters: '"@/\$`&'
         PasswordLength: 16
-      KmsKeyId: !Ref KmsKeyAlias
+      KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
 
   SecretAuroraClusterAttachment:
     Condition: UseSnapshotFalse
@@ -230,30 +256,27 @@ Resources:
               - lambda.amazonaws.com
             Action:
               - sts:AssumeRole
-      Path: "/"
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'
-      Policies:
-        -
-          PolicyName: "SecretAccess"
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              -
-                Effect: "Allow"
-                Action: "secretsmanager:GetSecretValue"
-                Resource:
-                  - !Ref AuroraMasterSecret
-                  - !Ref AuroraNextflowTowerDatabaseUserSecret
-        -
-          PolicyName: "DataAccess"
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              -
-                Effect: "Allow"
-                Action: "rds-data:*"
-                Resource: "*"
+
+  BootstrapLambdaPolicy:
+    Condition: UseSnapshotFalse
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allow access to SecretsManager and RDS for Bootstrap Lambda Role
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Action: secretsmanager:GetSecretValue
+          Resource:
+            - !Ref AuroraMasterSecret
+            - !Ref AuroraNextflowTowerDatabaseUserSecret
+        - Effect: Allow
+          Action: 'rds-data:*'
+          Resource: '*'
+      Roles:
+        - !Ref BootstrapLambdaRole
 
   BootstrapLambdaFunction:
     Condition: UseSnapshotFalse


### PR DESCRIPTION
Fix problem with kms key use in Aurora. The build is currently broken b/c the lambda role is attempting to use the workflows-infra key, but it is not a principal of that key.