### PR TITLE
Add ACM certificates for subdomains

### DIFF
--- a/config/develop/tower-dev-certificate.yaml
+++ b/config/develop/tower-dev-certificate.yaml
@@ -1,0 +1,11 @@
+template_path: remote/acm-certificate.yaml
+stack_name: tower-dev-certificate
+parameters:
+  Department: IBC
+  Project: Infrastructure
+  OwnerEmail: nextflow-admins@sagebase.org
+  DnsDomainName: sagebionetworks.org
+  DnsSubDomainName: tower-dev
+hooks:
+  before_launch:
+    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.3.0/templates/acm-certificate.yaml -O templates/remote/acm-certificate.yaml"

--- a/config/prod/tower-certificate.yaml
+++ b/config/prod/tower-certificate.yaml
@@ -1,0 +1,11 @@
+template_path: remote/acm-certificate.yaml
+stack_name: tower-certificate
+parameters:
+  Department: IBC
+  Project: Infrastructure
+  OwnerEmail: nextflow-admins@sagebase.org
+  DnsDomainName: sagebionetworks.org
+  DnsSubDomainName: tower
+hooks:
+  before_launch:
+    - !cmd "wget {{stack_group_config.aws_infra_templates_root_url}}/v0.3.0/templates/acm-certificate.yaml -O templates/remote/acm-certificate.yaml"


### PR DESCRIPTION
Acc. to various slack conversations as documented in [WORKFLOWS-40](https://sagebionetworks.jira.com/browse/WORKFLOWS-40), we have to create separate certificates for our new subdomains.