### PR TITLE
[WORKFLOWS-41] Grant ECS cluster with access to Aurora database cluster

### DIFF
--- a/config/develop/nextflow-aurora-mysql.yaml
+++ b/config/develop/nextflow-aurora-mysql.yaml
@@ -2,11 +2,13 @@ template_path: nextflow-aurora-mysql.yaml
 stack_name: nextflow-aurora-mysql
 dependencies:
   - develop/nextflow-vpc.yaml
+  - develop/nextflow-ecs-cluster.yaml
 parameters:
   VpcID: !stack_output_external nextflow-vpc::VPCId
   SubnetIDs:
     - !stack_output_external nextflow-vpc::PrivateSubnet1
     - !stack_output_external nextflow-vpc::PrivateSubnet2
+  EcsSecurityGroupId: !stack_output_external nextflow-ecs-cluster::EcsSecurityGroupId
   TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
 stack_tags:
   Department: IBC

--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -47,6 +47,10 @@ Parameters:
     Type: String
     Default: ''
 
+  EcsSecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: Security group ID for ECS cluster to grant database access
+
   TemplateRootUrl:
     Type: String
     Description: URL of S3 bucket where templates are deployed
@@ -166,6 +170,12 @@ Resources:
     Properties:
       VpcId: !Ref VpcID
       GroupDescription: Aurora Cluster Security Group
+      SecurityGroupIngress:
+        - Description: Inbound rule to allow database access to ECS cluster
+          SourceSecurityGroupId: !Ref EcsSecurityGroupId
+          IpProtocol: tcp
+          FromPort: 3306
+          ToPort: 3306
 
   CloudWatchDBClusterAuditLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
The Nextflow Tower backend is unable to connect to the database, and I suspect that it's due to the security group (SG) that's bound to the database cluster. This PR addresses this by allowing the ECS cluster SG to connect on port 3306 (MySQL). Since the database parameters (_e.g._ URL, username/password) are provided in a separate config (_i.e._ the ECS task definition), I think I can avoid a circular dependency between the Aurora DB SG and the ECS cluster SG. 