### PR TITLE
[WORKFLOWS-42] Send tower container logs to Cloudwatch

### DIFF
--- a/templates/nextflow-ecs-task-definition.yaml
+++ b/templates/nextflow-ecs-task-definition.yaml
@@ -116,6 +116,12 @@ Parameters:
     Type: String
     Description: Name of the tower config YAML file
 Resources:
+  TowerTaskLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: '/aws/ecs/task/nf-tower'
+      RetentionInDays: 30
+
   TowerTask:
     Type: AWS::ECS::TaskDefinition
     Properties:
@@ -134,6 +140,12 @@ Resources:
               HostPort: 6379
           Command:
             - --appendonly yes
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Sub '${AWS::Region}'
+              awslogs-group: !Ref TowerTaskLogGroup
+              awslogs-stream-prefix: 'tower'
         - Name: !Ref CronContainerName
           Image: !Ref CronContainerImage
           Memory: 2000
@@ -192,6 +204,12 @@ Resources:
             - ContainerPath: !Ref EfsVolumeMountPath
               ReadOnly: true
               SourceVolume: !Ref EfsVolumeName
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Sub '${AWS::Region}'
+              awslogs-group: !Ref TowerTaskLogGroup
+              awslogs-stream-prefix: 'tower'
         - Name: !Ref FrontendContainerName
           Image: !Ref FrontendContainerImage
           Memory: 2000
@@ -205,6 +223,12 @@ Resources:
           DependsOn:
             - ContainerName: !Ref BackendContainerName
               Condition: START
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Sub '${AWS::Region}'
+              awslogs-group: !Ref TowerTaskLogGroup
+              awslogs-stream-prefix: 'tower'
         - Name: !Ref BackendContainerName
           Hostname: !Ref BackendContainerName
           Memory: 2000
@@ -271,6 +295,12 @@ Resources:
             - ContainerPath: !Ref EfsVolumeMountPath
               ReadOnly: true
               SourceVolume: !Ref EfsVolumeName
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Sub '${AWS::Region}'
+              awslogs-group: !Ref TowerTaskLogGroup
+              awslogs-stream-prefix: 'tower'
 
 Outputs:
 

--- a/templates/nextflow-ecs-task-definition.yaml
+++ b/templates/nextflow-ecs-task-definition.yaml
@@ -115,6 +115,10 @@ Parameters:
   TowerConfigFileName:
     Type: String
     Description: Name of the tower config YAML file
+  AwslogsStreamPrefix:
+    Type: String
+    Description: Prefix used for CloudWatch log streams
+    Default: 'tower'
 Resources:
   TowerTaskLogGroup:
     Type: AWS::Logs::LogGroup
@@ -145,7 +149,7 @@ Resources:
             Options:
               awslogs-region: !Sub '${AWS::Region}'
               awslogs-group: !Ref TowerTaskLogGroup
-              awslogs-stream-prefix: 'tower'
+              awslogs-stream-prefix: !Ref AwslogsStreamPrefix
         - Name: !Ref CronContainerName
           Image: !Ref CronContainerImage
           Memory: 2000
@@ -209,7 +213,7 @@ Resources:
             Options:
               awslogs-region: !Sub '${AWS::Region}'
               awslogs-group: !Ref TowerTaskLogGroup
-              awslogs-stream-prefix: 'tower'
+              awslogs-stream-prefix: !Ref AwslogsStreamPrefix
         - Name: !Ref FrontendContainerName
           Image: !Ref FrontendContainerImage
           Memory: 2000
@@ -228,7 +232,7 @@ Resources:
             Options:
               awslogs-region: !Sub '${AWS::Region}'
               awslogs-group: !Ref TowerTaskLogGroup
-              awslogs-stream-prefix: 'tower'
+              awslogs-stream-prefix: !Ref AwslogsStreamPrefix
         - Name: !Ref BackendContainerName
           Hostname: !Ref BackendContainerName
           Memory: 2000
@@ -300,7 +304,7 @@ Resources:
             Options:
               awslogs-region: !Sub '${AWS::Region}'
               awslogs-group: !Ref TowerTaskLogGroup
-              awslogs-stream-prefix: 'tower'
+              awslogs-stream-prefix: !Ref AwslogsStreamPrefix
 
 Outputs:
 


### PR DESCRIPTION
I'm not sure if 30 days is appropriate as the retention period for these logs. We could make it shorter. 

You can find the test-deployment of the log group in the `nextflow-dev`: https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Fecs$252Ftask$252Fnf-tower