### PR TITLE
Refine budgets again based on notifications

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,13 +20,13 @@ services:
     - Amazon Elastic Compute Cloud - Compute
   storage:
     - Amazon Simple Storage Service
+    - Amazon Elastic Block Store
   security:
     - Amazon GuardDuty
     - AWS Config
   other:
     - Amazon API Gateway
     - Amazon DynamoDB
-    - Amazon Elastic Block Store
     - Amazon Elastic Container Service
     - Amazon Elastic File System
     - Amazon Elastic Load Balancing

--- a/src/sceptre/variables/dev.yaml
+++ b/src/sceptre/variables/dev.yaml
@@ -1,4 +1,4 @@
 compute_budget: "1000"
-storage_budget: "100"
+storage_budget: "250"
 security_budget: "100"
 other_budget: "250"

--- a/templates/budget.yaml
+++ b/templates/budget.yaml
@@ -132,14 +132,6 @@ Resources:
           IncludeTax: false
       NotificationsWithSubscribers:
         - Notification:
-            NotificationType: ACTUAL
-            ComparisonOperator: GREATER_THAN
-            Threshold: 80
-            ThresholdType: PERCENTAGE
-          Subscribers:
-            - SubscriptionType: SNS
-              Address: !Ref NotificationTopic
-        - Notification:
             NotificationType: FORECASTED
             ComparisonOperator: GREATER_THAN
             Threshold: 100
@@ -151,6 +143,14 @@ Resources:
             NotificationType: ACTUAL
             ComparisonOperator: GREATER_THAN
             Threshold: 100
+            ThresholdType: PERCENTAGE
+          Subscribers:
+            - SubscriptionType: SNS
+              Address: !Ref NotificationTopic
+        - Notification:
+            NotificationType: ACTUAL
+            ComparisonOperator: GREATER_THAN
+            Threshold: 200
             ThresholdType: PERCENTAGE
           Subscribers:
             - SubscriptionType: SNS


### PR DESCRIPTION
The current budget thresholds are a little noisy. I'm replacing an 80% threshold with a 200% threshold so that I can keep tabs on an expected surge in cost past 100%. I'm also moving EBS from `other` to `storage` since that cost will roughly correlate with compute. 

**Note to self:** Based on my test in nextflow-dev, I'll need to manually delete the budget CFN stacks before deploying this. 