### PR TITLE
Add ARN for htan-dev external account

### DIFF
--- a/config/projects-prod/htan-project.yaml
+++ b/config/projects-prod/htan-project.yaml
@@ -9,7 +9,7 @@ parameters:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/adam.taylor@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/milen.nikolov@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/brad.macdonald@sagebase.org'
-    - 'arn:aws:iam::888810830951:assumed-role/AWSReservedSSO_Administrator_bf3b4691e22cc3c6/adam.taylor@sagebase.org' # Provides for htan-dev cross-account access
+    - 'arn:aws:sts::888810830951:assumed-role/AWSReservedSSO_Administrator_bf3b4691e22cc3c6/adam.taylor@sagebase.org' # Provides for htan-dev cross-account access
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'


### PR DESCRIPTION
As discussed in [IBCSPRT-119](https://sagebionetworks.jira.com/servicedesk/customer/portal/5/IBCSPRT-119), I'm adding an ARN from the `htan-dev` account to enable cross-account transfer out of the `htan-project-tower-bucket` bucket.