### PR TITLE
[IT-2356] Setup secrets rotation in Aurora DB

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.58.4
+    rev: v0.76.2
     hooks:
       - id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$

--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -232,7 +232,8 @@ Resources:
       MasterUserSecret: !If
         - UseSnapshotTrue
         - !Ref 'AWS::NoValue'
-        - KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
+        - - KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
+          - SecretArn: !Ref AuroraMasterSecret
       ManageMasterUserPassword: true
       SnapshotIdentifier: !If [UseSnapshotTrue, !Ref SnapshotName, !Ref 'AWS::NoValue']
       StorageEncrypted:  !If [UseSnapshotTrue, !Ref 'AWS::NoValue', true]

--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -229,10 +229,11 @@ Resources:
         - UseSnapshotTrue
         - !Ref 'AWS::NoValue'
         - !Sub '{{resolve:secretsmanager:${AuroraMasterSecret}:SecretString:username}}'
-      MasterUserPassword: !If
+      MasterUserSecret: !If
         - UseSnapshotTrue
         - !Ref 'AWS::NoValue'
-        - !Sub '{{resolve:secretsmanager:${AuroraMasterSecret}:SecretString:password}}'
+        - KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
+      ManageMasterUserPassword: true
       SnapshotIdentifier: !If [UseSnapshotTrue, !Ref SnapshotName, !Ref 'AWS::NoValue']
       StorageEncrypted:  !If [UseSnapshotTrue, !Ref 'AWS::NoValue', true]
       DBClusterParameterGroupName: !Ref AuroraClusterParameterGroup

--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -232,8 +232,8 @@ Resources:
       MasterUserSecret: !If
         - UseSnapshotTrue
         - !Ref 'AWS::NoValue'
-        - - KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
-          - SecretArn: !Ref AuroraMasterSecret
+        - KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
+          SecretArn: !Ref AuroraMasterSecret
       ManageMasterUserPassword: true
       SnapshotIdentifier: !If [UseSnapshotTrue, !Ref SnapshotName, !Ref 'AWS::NoValue']
       StorageEncrypted:  !If [UseSnapshotTrue, !Ref 'AWS::NoValue', true]


### PR DESCRIPTION
Setup DB secrets on a rotation schedule for enhanced security.

* Amazon Aurora integrates with Secrets Manager to manage master
  user passwords for your DB clusters[1].  We setup the Aurora cluster
  to manage user passwords.  By default it's set to rotate secrets every 7 days.

* AWS docs provides some example cloudformation:
  Create a Secrets Manager secret for a master password[2]

* Update pre-commit cfn-python-lint version to pickup support for
   MasterUserSecret and ManageMasterUserPassword parameters.


[1] https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-secrets-manager.html
[2] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#aws-resource-rds-dbcluster--examples