### PR TITLE
Re-commit the env changes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
         run: find . -type f -name "*.j2" -exec /tmp/jinja2-lint/j2lint.py '{}' +
 
   deploy-dev:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/dev'
     needs:
       - validate
     uses: "./.github/workflows/rw-deploy.yaml"
@@ -44,8 +44,9 @@ jobs:
       tower-url: "https://tower-dev.sagebionetworks.org"
 
   deploy-prod:
-    if: github.ref == 'refs/heads/main'
-    needs: deploy-dev
+    if: github.ref == 'refs/heads/prod'
+    needs:
+      - validate
     uses: "./.github/workflows/rw-deploy.yaml"
     secrets: inherit
     with:
@@ -54,7 +55,7 @@ jobs:
       tower-url: "https://tower.sagebionetworks.org"
 
   deploy-ampad:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/prod'
     needs: deploy-prod
     uses: "./.github/workflows/rw-deploy.yaml"
     secrets: inherit


### PR DESCRIPTION
Update github action deployment strategy to use a specific branch approach
  * deploy to nextflow dev only upon a merge to the `dev` branch
  * deploy to nextflow prod only upon a merge to the `prod`  branch
  * only deploy to ampad after a deployment to prod.

Todo after merging this PR:
  * rename the `main` branch to `dev`
  * Create `prod` branch
  * delete the `main` branch
  * Reset deployment branch protection in environments to allow for deployment on dev and prod respectively

The new workflow will be:
  * Create PR targeting the `dev` branch (dev is the default branch so it'll auto target it)
  * Review and approve PR
  * Merge to the dev branch
  * Deploy to nextflow dev
    * [Optional] Create PR for merge from dev  branch to prod branch 
    * [Optional] Review and approve PR
    * Merge dev branch to prod branch
    * Deploy to prod and ampad 

Note: Optional steps can be replaced with a direct push of the merge to the prod branch