### PR TITLE
Parameterize `notifications_email` for budgets

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,7 +9,7 @@ default_stack_tags:
   Project: Infrastructure
   OwnerEmail: nextflow-admins@sagebase.org
   CostCenter: NO PROGRAM / 000000
-notifications_email: nextflow-admins@sagebase.org
+notifications_email: {{ var.notifications_email | default("nextflow-admins@sagebase.org") }}
 budgets:
   compute: {{ var.compute_budget | default("1000") }}
   storage: {{ var.storage_budget | default("500") }}

--- a/src/sceptre/variables/ampad.yaml
+++ b/src/sceptre/variables/ampad.yaml
@@ -1,3 +1,4 @@
+notifications_email: aws.strides-ampad-workflows@sagebase.org
 compute_budget: "10000"
 storage_budget: "10000"
 security_budget: "500"


### PR DESCRIPTION
The purpose of this PR is to allow each account to send budget notifications to separate email addresses. We are starting by updating the recipient for the STRIDES AMP-AD AWS account. 