### PR TITLE
[IT-2360] Setup IAM roles for tower

### DIFF
--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -145,8 +145,8 @@ Resources:
     Type: "AWS::IAM::Role"
     Properties:
       ManagedPolicyArns:
-        - !Sub '!ImportValue ${AWS::Region}-nextflow-forge-iam-policy-NextFlowForgePolicyArn'
-        - !Sub '!ImportValue ${AWS::Region}-nextflow-launch-iam-policy-NextFlowLaunchPolicyArn'
+        - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-forge-iam-policy-NextFlowForgePolicyArn
+        - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-launch-iam-policy-NextFlowLaunchPolicyArn
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -170,7 +170,8 @@ Resources:
           - Sid: AllowEcsServiceRole2AssumeRole
             Effect: Allow
             Principal:
-              AWS: !Sub '!ImportValue ${AWS::Region}-nextflow-ecs-service-EcsServiceRoleArn'
+              AWS:
+                - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-ecs-service-EcsServiceRoleArn
             Action: sts:AssumeRole
 
   TowerForgeBatchHeadJobPolicy:

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -141,6 +141,38 @@ Resources:
               Service:
                 - ecs-tasks.amazonaws.com
 
+  TowerRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      ManagedPolicyArns:
+        - !Sub '!ImportValue ${AWS::Region}-nextflow-forge-iam-policy-NextFlowForgePolicyArn'
+        - !Sub '!ImportValue ${AWS::Region}-nextflow-launch-iam-policy-NextFlowLaunchPolicyArn'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service: eks.amazonaws.com
+            Action: sts:AssumeRole
+          - Sid: AllowEc2AssumeRole
+            Effect: Allow
+            Principal:
+              AWS: !Ref AccountAdminArns
+            Action: sts:AssumeRole
+          - Sid: AllowEcsServiceRole2AssumeRole
+            Effect: Allow
+            Principal:
+              AWS: !Sub '!ImportValue ${AWS::Region}-nextflow-ecs-service-EcsServiceRoleArn'
+            Action: sts:AssumeRole
+
   TowerForgeBatchHeadJobPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -582,6 +614,11 @@ Outputs:
     Value: !GetAtt TowerForgeServiceRole.Arn
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceRoleArn"
+
+  TowerRoleArn:
+    Value: !GetAtt TowerRole.Arn
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerRoleArn"
 
   TowerForgeBatchHeadJobRole:
     Value: !Ref TowerForgeBatchHeadJobRole


### PR DESCRIPTION
Allow tower to use roles instead of a service user to access AWS resources. This a 2nd attempt at PR #181, that one failed to deploy.

depends on #204