### PR TITLE
Increase intance type size

### DIFF
--- a/config/infra-prod/nextflow-ecs-cluster.yaml
+++ b/config/infra-prod/nextflow-ecs-cluster.yaml
@@ -8,6 +8,7 @@ dependencies:
 parameters:
   EcsSecurityGroupId: !stack_output_external nextflow-ecs-security-group::SecurityGroupId
   SubnetId: !stack_output_external nextflow-vpc::PrivateSubnet
+  EcsInstanceType: "c4.4xlarge"
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}


### PR DESCRIPTION
The instance/ontainer that's running `redis-check-aof --fix appendonly.aof` is super duper slow which is causing the nexflow-tower service really slow to start.  We increase the instance size to see if it will run faster to unblock the redis/frontend/backend services from starting.