### PR TITLE
bump memory and add debug for redis check aof

### DIFF
--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -178,7 +178,7 @@ Resources:
         # https://sagebionetworks.jira.com/browse/WORKFLOWS-521
         - Name: !Sub '${RedisContainerName}-CheckAOF'
           Image: !Ref RedisContainerImage
-          Memory: 2000
+          Memory: 4000
           Cpu: 0
           Essential: false
           EntryPoint:
@@ -187,7 +187,7 @@ Resources:
           # interactive prompt and doesn't have an option to disable it
           Command:
             - -c
-            - "yes | redis-check-aof --fix appendonly.aof"
+            - echo 'start redis-check-aof' && 'yes | redis-check-aof --fix appendonly.aof' && echo 'redis-check-aof complete'
           MountPoints:
             - ContainerPath: /data
               SourceVolume: !Ref EfsVolumeName


### PR DESCRIPTION
the redis-check-aof command is really so.  try giving it more memory to make it run faster.  Also add some debug statements so that we can log how long it takes to run.