### PR TITLE
Attempt to fix 'redis-check-aof' command

### DIFF
--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -185,9 +185,12 @@ Resources:
             - /bin/sh
           # The `yes` command is needed because `redis-check-aof` has an
           # interactive prompt and doesn't have an option to disable it
+          # Use parentheses around the piped commands to enforce order
+          # between `|` and `&&` operators, and wrap the entire string
+          # in double-quotes to prevent YAML parsing of the `|` operator.
           Command:
             - -c
-            - "yes | redis-check-aof --fix appendonly.aof"
+            - "echo 'start redis-check-aof' && ( yes | redis-check-aof --fix appendonly.aof ) && echo 'redis-check-aof complete'"
           MountPoints:
             - ContainerPath: /data
               SourceVolume: !Ref EfsVolumeName


### PR DESCRIPTION
The current command is failing with `/bin/sh` failing to find an executable called `yes | redis-check-aof --fix appendonly.aof`.

Replace the single quotes with parantheses, which will fork a sub-process for the piped commands to run in, and wrap the entire YAML string in double quotes to prevent YAML from parsing the pipe operator.