### PR TITLE
bump memory for redis check aof

### DIFF
--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -178,7 +178,7 @@ Resources:
         # https://sagebionetworks.jira.com/browse/WORKFLOWS-521
         - Name: !Sub '${RedisContainerName}-CheckAOF'
           Image: !Ref RedisContainerImage
-          Memory: 2000
+          Memory: 4000
           Cpu: 0
           Essential: false
           EntryPoint:


### PR DESCRIPTION
the redis-check-aof command is really so.  try giving it more memory to make it run faster.