### PR TITLE
log timestap for redis-check-aof command

### DIFF
--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -190,7 +190,7 @@ Resources:
           # in double-quotes to prevent YAML parsing of the `|` operator.
           Command:
             - -c
-            - "echo 'start redis-check-aof' && ( yes | redis-check-aof --fix appendonly.aof ) && echo 'redis-check-aof complete'"
+            - "echo 'start redis-check-aof' && (date) && ( yes | redis-check-aof --fix appendonly.aof ) && echo 'redis-check-aof complete' && (date)"
           MountPoints:
             - ContainerPath: /data
               SourceVolume: !Ref EfsVolumeName


### PR DESCRIPTION
Add timestamp to help us figure out how long it takes for redis-check-aof scan to execute.