### PR TITLE
set assume role timeouts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,6 +42,7 @@ jobs:
       job-environment: "workflows-nextflow-dev"
       sceptre-suffix: "dev"
       tower-url: "https://tower-dev.sagebionetworks.org"
+      aws-assume-role-duration: "3600"
 
   deploy-prod:
     if: github.ref == 'refs/heads/prod'
@@ -53,6 +54,7 @@ jobs:
       job-environment: "workflows-nextflow-prod"
       sceptre-suffix: "prod"
       tower-url: "https://tower.sagebionetworks.org"
+      aws-assume-role-duration: "14400"
 
   deploy-ampad:
     if: github.ref == 'refs/heads/prod'

--- a/.github/workflows/rw-deploy.yaml
+++ b/.github/workflows/rw-deploy.yaml
@@ -32,14 +32,14 @@ jobs:
       - name: Install dependencies
         run: pipenv install --dev
 
-      - name: Assume AWS role in dev account
+      - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.CI_USER_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CI_USER_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           role-to-assume: ${{ secrets.CI_ROLE_TO_ASSUME }}
-          role-duration-seconds: 3600
+          role-duration-seconds: ${{ inputs.aws-assume-role-duration }}
 
       - name: Deploy common configuration
         run: >


### PR DESCRIPTION
The redis-check-aof step on deployment takes significantly more time in the prod account than in the dev account.  We need to assume the aws role for longer period of time when deploying to prod.