### PR TITLE
EFS performance boost

### DIFF
--- a/templates/nextflow-efs-file-system.yaml
+++ b/templates/nextflow-efs-file-system.yaml
@@ -28,6 +28,8 @@ Resources:
       BackupPolicy:
         Status: DISABLED
       Encrypted: true
+      ThroughputMode: provisioned
+      ProvisionedThroughputInMibps: 1024
 
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
The EFS performance is saturated by the redis-check-aof command on the nexflow prod account.  The result is that it is taking 2hrs to execute the redis check. The EFS volume contains a few files one of them being the appendonly.aof file that's very large (~15GB).  We attempt to boost the EFS performance by configuring higher throughput for the EFS volume.  Hopefully this will allow redis-check-aof to scan the appendonly.aof file faster.


we could also set PerformanceMode=maxIO however the doc says 
`The performance mode can't be changed after the file system has been created.`