### PR TITLE
add GH action permissions for OIDC

### DIFF
--- a/.github/workflows/rw-deploy.yaml
+++ b/.github/workflows/rw-deploy.yaml
@@ -23,6 +23,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.job-environment }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
[GH action docs](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) says permissions are required for OIDC
