### PR TITLE
Allow GH OIDC access to KMS key

### DIFF
--- a/config/infra-ampad/workflows-kms-key.yaml
+++ b/config/infra-ampad/workflows-kms-key.yaml
@@ -7,6 +7,7 @@ parameters:
   AccountAdminArns:
     - {{stack_group_config.sso_admin_role.arn}}
     - !stack_output_external workflows-nextflow-ci-service-account::ServiceRoleArn
+    - !stack_output_external workflows-infra-kms-key::KeyArn
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}

--- a/config/infra-dev/workflows-kms-key.yaml
+++ b/config/infra-dev/workflows-kms-key.yaml
@@ -7,6 +7,7 @@ parameters:
   AccountAdminArns:
     - {{stack_group_config.sso_admin_role.arn}}
     - !stack_output_external workflows-nextflow-ci-service-account::ServiceRoleArn
+    - !stack_output_external workflows-infra-kms-key::KeyArn
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}

--- a/config/infra-prod/workflows-kms-key.yaml
+++ b/config/infra-prod/workflows-kms-key.yaml
@@ -7,6 +7,7 @@ parameters:
   AccountAdminArns:
     - {{stack_group_config.sso_admin_role.arn}}
     - !stack_output_external workflows-nextflow-ci-service-account::ServiceRoleArn
+    - !stack_output_external workflows-infra-kms-key::KeyArn
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}


### PR DESCRIPTION
We are now using github action OIDC for deployments and that role 
needs access to the workflow-infra KMS key to access secrets manager
resources.