### PR TITLE
fix stack dependencies

### DIFF
--- a/config/infra-dev/nextflow-aurora-mysql.yaml
+++ b/config/infra-dev/nextflow-aurora-mysql.yaml
@@ -2,6 +2,7 @@ template:
   path: nextflow-aurora-mysql.yaml
 stack_name: nextflow-aurora-mysql
 dependencies:
+  - infra-dev/workflows-kms-key.yaml
   - infra-dev/nextflow-vpc.yaml
   - infra-dev/nextflow-ecs-security-group.yaml
 

--- a/config/infra-dev/nextflow-tower-config-bucket.yaml
+++ b/config/infra-dev/nextflow-tower-config-bucket.yaml
@@ -2,6 +2,8 @@
 template:
   path: nextflow-tower-config-bucket.yaml
 stack_name: {{ stack_name }}
+dependencies:
+  - infra-dev/workflows-kms-key.yaml
 
 parameters:
   BucketName: {{ stack_name }}

--- a/config/infra-dev/smtp-credentials.yaml
+++ b/config/infra-dev/smtp-credentials.yaml
@@ -1,6 +1,8 @@
 template:
   path: smtp-credentials.yaml
 stack_name: smtp-credentials
+dependencies:
+  - infra-dev/workflows-kms-key.yaml
 
 parameters:
   IamAccessKeyVersion: '1'

--- a/config/infra-prod/nextflow-aurora-mysql.yaml
+++ b/config/infra-prod/nextflow-aurora-mysql.yaml
@@ -2,6 +2,7 @@ template:
   path: nextflow-aurora-mysql.yaml
 stack_name: nextflow-aurora-mysql
 dependencies:
+  - infra-prod/workflows-kms-key.yaml
   - infra-prod/nextflow-vpc.yaml
   - infra-prod/nextflow-ecs-security-group.yaml
 

--- a/config/infra-prod/nextflow-tower-config-bucket.yaml
+++ b/config/infra-prod/nextflow-tower-config-bucket.yaml
@@ -2,6 +2,8 @@
 template:
   path: nextflow-tower-config-bucket.yaml
 stack_name: {{ stack_name }}
+dependencies:
+  - infra-prod/workflows-kms-key.yaml
 
 parameters:
   BucketName: {{ stack_name }}

--- a/config/infra-prod/smtp-credentials.yaml
+++ b/config/infra-prod/smtp-credentials.yaml
@@ -1,6 +1,8 @@
 template:
   path: smtp-credentials.yaml
 stack_name: smtp-credentials
+dependencies:
+  - infra-prod/workflows-kms-key.yaml
 
 parameters:
   IamAccessKeyVersion: '1'

--- a/config/infra-prod/workflows-kms-key.yaml
+++ b/config/infra-prod/workflows-kms-key.yaml
@@ -1,6 +1,8 @@
 template:
   path: workflows-kms-key.yaml
 stack_name: workflows-infra-kms-key
+dependencies:
+  - infra-prod/workflows-kms-key.yaml
 
 parameters:
   TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'


### PR DESCRIPTION
We need to deploy kms key updates before deploying resources that use those keys
otherwise the CI may encounter errors accessing secrets from the AWS secrets manager.