### PR TITLE
[IT-2968] Revert IT-2360 due to ampad deployment failure

### DIFF
--- a/src/tower/resources/environment.yaml
+++ b/src/tower/resources/environment.yaml
@@ -25,4 +25,3 @@ TOWER_OIDC_TOKEN_IMPORT: "!If [ HasTowerOidcClient, !Ref TowerOidcTokenImport, !
 TOWER_ROOT_USERS: "!If [ HasTowerRootUsers, !Join [',', !Ref TowerRootUsers], !Ref AWS::NoValue]"
 TOWER_USER_WORKSPACE_ENABLED: "!Ref 'TowerUserWorkspace'"
 TOWER_CONFIG_FILE: "!Sub '${EfsVolumeMountPath}/${TowerConfigFileName}'"
-TOWER_ALLOW_INSTANCE_CREDENTIALS: "true"

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -141,39 +141,6 @@ Resources:
               Service:
                 - ecs-tasks.amazonaws.com
 
-  TowerRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      ManagedPolicyArns:
-        - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-forge-iam-policy-NextFlowForgePolicyArn
-        - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-launch-iam-policy-NextFlowLaunchPolicyArn
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: ec2.amazonaws.com
-            Action: sts:AssumeRole
-          - Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-            Action: sts:AssumeRole
-          - Effect: Allow
-            Principal:
-              Service: eks.amazonaws.com
-            Action: sts:AssumeRole
-          - Sid: AllowEc2AssumeRole
-            Effect: Allow
-            Principal:
-              AWS: !Ref AccountAdminArns
-            Action: sts:AssumeRole
-          - Sid: AllowEcsServiceRole2AssumeRole
-            Effect: Allow
-            Principal:
-              AWS:
-                - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-ecs-service-EcsServiceRoleArn
-            Action: sts:AssumeRole
-
   TowerForgeBatchHeadJobPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -615,11 +582,6 @@ Outputs:
     Value: !GetAtt TowerForgeServiceRole.Arn
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceRoleArn"
-
-  TowerRoleArn:
-    Value: !GetAtt TowerRole.Arn
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerRoleArn"
 
   TowerForgeBatchHeadJobRole:
     Value: !Ref TowerForgeBatchHeadJobRole


### PR DESCRIPTION
This reverts the change that caused ampad project deployments to fail.
We will need to figure out a different solution and try again.