### PR TITLE
Revert instance type and memory

### DIFF
--- a/config/infra-prod/nextflow-ecs-cluster.yaml
+++ b/config/infra-prod/nextflow-ecs-cluster.yaml
@@ -8,7 +8,6 @@ dependencies:
 parameters:
   EcsSecurityGroupId: !stack_output_external nextflow-ecs-security-group::SecurityGroupId
   SubnetId: !stack_output_external nextflow-vpc::PrivateSubnet
-  EcsInstanceType: "c4.4xlarge"
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -178,7 +178,7 @@ Resources:
         # https://sagebionetworks.jira.com/browse/WORKFLOWS-521
         - Name: !Sub '${RedisContainerName}-CheckAOF'
           Image: !Ref RedisContainerImage
-          Memory: 4000
+          Memory: 2000
           Cpu: 0
           Essential: false
           EntryPoint:


### PR DESCRIPTION
Increasing the instance size and memory did not make redis-check-aof run
faster.  I believe boosting EFS performance (PR #214) did the trick.  Revert
the changes for instance type because it's not needed. 