### PR TITLE
Set assume role duration to default

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,7 +55,6 @@ jobs:
       sceptre-suffix: "prod"
       tower-url: "https://tower.sagebionetworks.org"
       aws-role-to-assume: "arn:aws:iam::728882028485:role/sagebase-github-oidc-workflows-prod-nextflow-infra"
-      aws-assume-role-duration: 14400
 
   deploy-ampad:
     if: github.ref == 'refs/heads/prod'


### PR DESCRIPTION
Currently the deployment to prod account is only taking ~15 mins Reduce the GH OIDC assume role session window to the default which is 3600 secs.