### PR TITLE
[IT-2950] Update nextflow tower version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v22.4.1
+tower_version: v23.1.3
 default_stack_tags:
   Department: IBC
   Project: Infrastructure

--- a/templates/nextflow-forge-iam-policy.yaml
+++ b/templates/nextflow-forge-iam-policy.yaml
@@ -7,7 +7,8 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-        - Effect: Allow
+        - Sid: TowerForge0
+          Effect: Allow
           Action:
             - ssm:GetParameters
             - iam:CreateInstanceProfile
@@ -59,6 +60,35 @@ Resources:
             - elasticfilesystem:UpdateFileSystem
             - elasticfilesystem:PutLifecycleConfiguration
             - elasticfilesystem:TagResource
+          Resource: "*"
+        - Sid: TowerLaunch0
+          Effect: Allow
+          Action:
+            - s3:Get*
+            - s3:List*
+            - batch:DescribeJobQueues
+            - batch:CancelJob
+            - batch:SubmitJob
+            - batch:ListJobs
+            - batch:DescribeComputeEnvironments
+            - batch:TerminateJob
+            - batch:DescribeJobs
+            - batch:RegisterJobDefinition
+            - batch:DescribeJobDefinitions
+            - ecs:DescribeTasks
+            - ec2:DescribeInstances
+            - ec2:DescribeInstanceTypes
+            - ec2:DescribeInstanceAttribute
+            - ecs:DescribeContainerInstances
+            - ec2:DescribeInstanceStatus
+            - ec2:DescribeImages
+            - logs:Describe*
+            - logs:Get*
+            - logs:List*
+            - logs:StartQuery
+            - logs:StopQuery
+            - logs:TestMetricFilter
+            - logs:FilterLogEvents
           Resource: "*"
 Outputs:
   NextFlowForgePolicyArn:


### PR DESCRIPTION
* Update to ver 23.3.3
* NFT docs[1] says this update requires an update to the permission policy

We are not using NFT Launch or Wave yet so no need to make updates to accomodate those.

[1] https://help.tower.nf/23.1/enterprise/release_notes/23.1/#updated-aws-permissions-policies