### PR TITLE
[IT-2944] enable Wave for nextflow workspaces

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -671,7 +671,7 @@ class TowerWorkspace:
                     "preRunScript": "NXF_OPTS='-Xms7g -Xmx14g'",
                     "region": self.org.aws.region,
                     "resourceLabelIds": label_ids,
-                    "waveEnabled": False,
+                    "waveEnabled": True,
                     "workDir": f"s3://{self.stack['TowerScratch']}/work",
                     "forge": {
                         "allocStrategy": alloc_strategy,


### PR DESCRIPTION
Nextflow Wave has already been setup and enabled for the compute environments with TOWER_ENABLE_WAVE=true and
WAVE_SERVER_URL="https://wave.seqera.io" configuration settings[1]. Now we enable Wave for the workspaces.

[1] https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/blob/dev/src/tower/resources/environment.yaml