### PR TITLE
Create nf-test.yaml

### DIFF
--- a/config/projects-prod/nf-test.yaml
+++ b/config/projects-prod/nf-test.yaml
@@ -1,0 +1,25 @@
+template:
+  path: tower-project.j2
+stack_name: nf-project
+dependencies:
+  - common/nextflow-forge-iam-policy.yaml
+  - common/nextflow-launch-iam-policy.yaml
+
+parameters:
+  S3ReadWriteAccessArns:
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org'
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/robert.allaway@sagebase.org' # Provides access to HTAN buckets in SciComp
+  AllowSynapseIndexing: Enabled
+  AccountAdminArns:
+    - '{{stack_group_config.sso_admin_role.arn}}'
+    - !stack_output_external sagebase-github-oidc-workflows-prod-nextflow-infra::ProviderRoleArn
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
+  TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
+  TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+
+stack_tags:
+  Department: SCCE
+  Project: Neurofibromatosis
+  OwnerEmail: robert.allaway@sagebase.org
+  CostCenter: NTAP NF Addendum 4 / 301100


### PR DESCRIPTION
Trying to debug why we cannot use external buckets on nextflow in nf-add5-project. This is a copy of htan-project, slightly modified to have the right ARNs. 