### PR TITLE
[IT-3184] parameterize throughtput mode

### DIFF
--- a/config/infra-dev/nextflow-efs-file-system.yaml
+++ b/config/infra-dev/nextflow-efs-file-system.yaml
@@ -12,6 +12,7 @@ parameters:
   SubnetId: !stack_output_external nextflow-ecs-cluster::EcsAutoScalingGroupSubnetId
   EcsSecurityGroupId: !stack_output_external nextflow-ecs-security-group::SecurityGroupId
   NextflowTowerConfigBucketArn: !stack_output_external nextflow-tower-config-dev::BucketArn
+  ThroughputMode: provisioned
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}

--- a/config/infra-prod/nextflow-efs-file-system.yaml
+++ b/config/infra-prod/nextflow-efs-file-system.yaml
@@ -12,6 +12,8 @@ parameters:
   SubnetId: !stack_output_external nextflow-ecs-cluster::EcsAutoScalingGroupSubnetId
   EcsSecurityGroupId: !stack_output_external nextflow-ecs-security-group::SecurityGroupId
   NextflowTowerConfigBucketArn: !stack_output_external nextflow-tower-config::BucketArn
+  ThroughputMode: provisioned
+  ProvisionedThroughputInMibps: 1024
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}

--- a/templates/nextflow-efs-file-system.yaml
+++ b/templates/nextflow-efs-file-system.yaml
@@ -19,6 +19,25 @@ Parameters:
     Type: String
     Description: ARN of the S3 bucket where the tower config is stored
 
+  ThroughputMode:
+    Type: String
+    AllowedValues:
+      - bursting
+      - elastic
+      - provisioned
+    Default: bursting
+    Description: The throughput mode for the EFS file system
+
+  ProvisionedThroughputInMibps:
+    Type: Number
+    MinValue: 1
+    MaxValue: 3414
+    Default: 200
+    Description: The throughput in MiBps for the EFS file system
+
+Conditions:
+  ThroughputModeIsProvisioned: !Equals [ "provisioned", !Ref ThroughputMode ]
+
 Resources:
 
   FileSystem:
@@ -28,8 +47,8 @@ Resources:
       BackupPolicy:
         Status: DISABLED
       Encrypted: true
-      ThroughputMode: provisioned
-      ProvisionedThroughputInMibps: 1024
+      ThroughputMode: !Ref ThroughputMode
+      ProvisionedThroughputInMibps: !If [ ThroughputModeIsProvisioned, !Ref ProvisionedThroughputInMibps, !Ref "AWS::NoValue" ]
 
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
* Parameterize ThroughputMode and ProvisionedThroughputInMibps parameters so that we can configure them with different values per environment
* Configure 200 Mibps for dev and 1024 Mibps for prod in an attempt to reduce cost for the dev environment.