### PR TITLE
pass value as string instead of int

### DIFF
--- a/config/infra-prod/nextflow-efs-file-system.yaml
+++ b/config/infra-prod/nextflow-efs-file-system.yaml
@@ -13,7 +13,7 @@ parameters:
   EcsSecurityGroupId: !stack_output_external nextflow-ecs-security-group::SecurityGroupId
   NextflowTowerConfigBucketArn: !stack_output_external nextflow-tower-config::BucketArn
   ThroughputMode: provisioned
-  ProvisionedThroughputInMibps: 1024
+  ProvisionedThroughputInMibps: "1024"
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}


### PR DESCRIPTION
fix deployment error.. 
```
"Parameter validation failed:\nInvalid type for parameter Parameters[5].
ParameterValue, value: 1024, type: <class 'int'>, valid types: <class 'str'>"
```