### PR TITLE
Update pre-commit linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,39 +2,39 @@ default_language_version:
     python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.30.0
+    rev: v1.32.0
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.77.0
+    rev: v0.82.0
     hooks:
       - id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.1
+    rev: v1.5.4
     hooks:
       - id: remove-tabs
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.6.0
     hooks:
       - id: mypy
         args: [--implicit-optional]
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.10.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         args: ["--max-line-length", "88"]
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.22.0
+    rev: 0.27.0
     hooks:
       - id: check-github-workflows
       - id: check-github-actions


### PR DESCRIPTION
Used autoupdate to update precommit linters..

```
pre-commit autoupdate
[https://github.com/pre-commit/pre-commit-hooks] updating v4.4.0 -> v4.5.0
[https://github.com/adrienverge/yamllint] updating v1.30.0 -> v1.32.0
[https://github.com/awslabs/cfn-python-lint] updating v0.77.0 -> v0.82.0
[https://github.com/Lucas-C/pre-commit-hooks] updating v1.5.1 -> v1.5.4
[https://github.com/pre-commit/mirrors-mypy] updating v1.2.0 -> v1.6.0
[https://github.com/psf/black] updating 23.3.0 -> 23.10.0
[https://github.com/pycqa/flake8] updating 6.0.0 -> 6.1.0
[https://github.com/sirosen/check-jsonschema] updating 0.22.0 -> 0.27.0
```