### PR TITLE
[IT-3184] Setup Elasticache for nextflow

### DIFF
--- a/config/infra-dev/nextflow-elasticache-cluster.yaml
+++ b/config/infra-dev/nextflow-elasticache-cluster.yaml
@@ -1,0 +1,15 @@
+template:
+  path: nextflow-elasticache-cluster.yaml
+stack_name: nextflow-elasticache-cluster
+dependencies:
+  - infra-dev/nextflow-vpc.yaml
+  - infra-dev/nextflow-ecs-security-group.yaml
+  - infra-dev/nextflow-ecs-cluster.yaml
+
+parameters:
+  VpcId: !stack_output_external nextflow-vpc::VPCId
+  SubnetId: !stack_output_external nextflow-ecs-cluster::EcsAutoScalingGroupSubnetId
+  EcsSecurityGroupId: !stack_output_external nextflow-ecs-security-group::SecurityGroupId
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/templates/nextflow-elasticache-cluster.yaml
+++ b/templates/nextflow-elasticache-cluster.yaml
@@ -14,24 +14,16 @@ Parameters:
     Type: String
 
 Resources:
-  SecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: ECS Security Group
-      VpcId: !Ref VpcId
-  SecurityGroupIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: !GetAtt SecurityGroup.GroupId
-      SourceSecurityGroupId: !Ref EcsSecurityGroupId
-      IpProtocol: tcp
-      FromPort: 6379
-      ToPort: 6379
   ElasticacheSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
       GroupDescription: Elasticache Security Group
-      SecurityGroupIngress: !Ref SecurityGroupIngress
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - SourceSecurityGroupId: !Ref EcsSecurityGroupId
+          IpProtocol: tcp
+          FromPort: 6379
+          ToPort: 6379
   ElasticacheCluster:
     Type: AWS::ElastiCache::CacheCluster
     Properties:

--- a/templates/nextflow-elasticache-cluster.yaml
+++ b/templates/nextflow-elasticache-cluster.yaml
@@ -1,0 +1,66 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Elasticache cluster for Nextflow Tower
+Parameters:
+  VpcId:
+    Description: ID of VPC
+    Type: AWS::EC2::VPC::Id
+
+  EcsSecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: Security group ID for ECS cluster to grant database access
+
+  SubnetId:
+    Description: The ID of the ECS subnet group.
+    Type: String
+
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: ECS Security Group
+      VpcId: !Ref VpcId
+  SecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt SecurityGroup.GroupId
+      SourceSecurityGroupId: !Ref EcsSecurityGroupId
+      IpProtocol: tcp
+      FromPort: 6379
+      ToPort: 6379
+  ElasticacheSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Elasticache Security Group
+      SecurityGroupIngress: !Ref SecurityGroupIngress
+  ElasticacheCluster:
+    Type: AWS::ElastiCache::CacheCluster
+    Properties:
+      CacheNodeType: cache.r6gd.xlarge
+      Engine: redis
+      NumCacheNodes: '1'
+      TransitEncryptionEnabled: true
+      VpcSecurityGroupIds:
+        - !GetAtt ElasticacheSecurityGroup.GroupId
+      CacheSubnetGroupName: !Ref SubnetId
+
+Outputs:
+
+  ElasticacheClusterEndpointAddress:
+    Value: !GetAtt ElasticacheCluster.ConfigurationEndpoint.Address
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ElasticacheClusterEndpointAddress'
+
+  ElasticacheClusterEndpointPort:
+    Value: !GetAtt ElasticacheCluster.ConfigurationEndpoint.Port
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ElasticacheClusterEndpointPort'
+
+  RedisEndpointAddress:
+    Value: !GetAtt ElasticacheCluster.RedisEndpoint.Address
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-RedisEndpointAddress'
+
+  RedisEndpointPort:
+    Value: !GetAtt ElasticacheCluster.RedisEndpoint.Port
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-RedisEndpointPort'


### PR DESCRIPTION
Per nextflow issue[1], Seqera suggest we use AWS elasticache with Redis
instead of hosting redis in a docker container.  This step is to
setup Elasticache for nextflow.

Note: once setup, we will need to configure nextflow'S TOWER_REDIS_URL[2]
parameter to use the AWS-generated endpoint. The backend and cron containers
need to be aware of this configuration in the environment section of the ECS template.

example:
```
## tower.env. I have enabled the encryption for this Redis instance.
TOWER_REDIS_URL=rediss://mp-cache-0001-001.mp-cache.3pconu.use1.cache.amazonaws.com:6379
```

[1] https://support.seqera.io/support/tickets/4048
[2] https://help.tower.nf/23.2/enterprise/configuration/overview/#tower-and-redis-databases:~:text=TOWER_REDIS_URL,redis%3A//redis%3A6379