### PR TITLE
[IT-3184] Fix nextflow Elasticache setup

### DIFF
--- a/config/infra-dev/nextflow-elasticache-cluster.yaml
+++ b/config/infra-dev/nextflow-elasticache-cluster.yaml
@@ -8,7 +8,10 @@ dependencies:
 
 parameters:
   VpcId: !stack_output_external nextflow-vpc::VPCId
-  SubnetId: !stack_output_external nextflow-ecs-cluster::EcsAutoScalingGroupSubnetId
+  VpcSubnetIDs:
+    - !stack_output_external nextflow-vpc::PrivateSubnet1
+    - !stack_output_external nextflow-vpc::PrivateSubnet2
+    - !stack_output_external nextflow-vpc::PrivateSubnet3
   EcsSecurityGroupId: !stack_output_external nextflow-ecs-security-group::SecurityGroupId
 
 stack_tags:

--- a/templates/nextflow-elasticache-cluster.yaml
+++ b/templates/nextflow-elasticache-cluster.yaml
@@ -5,13 +5,13 @@ Parameters:
     Description: ID of VPC
     Type: AWS::EC2::VPC::Id
 
+  VpcSubnetIDs:
+    Description: The VPC subnet IDs.
+    Type: List<AWS::EC2::Subnet::Id>
+
   EcsSecurityGroupId:
     Type: AWS::EC2::SecurityGroup::Id
     Description: Security group ID for ECS cluster to grant database access
-
-  SubnetId:
-    Description: The ID of the ECS subnet group.
-    Type: String
 
 Resources:
   ElasticacheSecurityGroup:
@@ -24,28 +24,22 @@ Resources:
           IpProtocol: tcp
           FromPort: 6379
           ToPort: 6379
+  ElasticacheSubnetGroup:
+    Type: AWS::ElastiCache::SubnetGroup
+    Properties:
+      Description: Elasticache subnet group
+      SubnetIds: !Ref VpcSubnetIDs
   ElasticacheCluster:
     Type: AWS::ElastiCache::CacheCluster
     Properties:
-      CacheNodeType: cache.r6gd.xlarge
+      CacheNodeType: cache.r6g.large
       Engine: redis
-      NumCacheNodes: '1'
-      TransitEncryptionEnabled: true
+      NumCacheNodes: "1"
       VpcSecurityGroupIds:
         - !GetAtt ElasticacheSecurityGroup.GroupId
-      CacheSubnetGroupName: !Ref SubnetId
+      CacheSubnetGroupName: !Ref ElasticacheSubnetGroup
 
 Outputs:
-
-  ElasticacheClusterEndpointAddress:
-    Value: !GetAtt ElasticacheCluster.ConfigurationEndpoint.Address
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ElasticacheClusterEndpointAddress'
-
-  ElasticacheClusterEndpointPort:
-    Value: !GetAtt ElasticacheCluster.ConfigurationEndpoint.Port
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ElasticacheClusterEndpointPort'
 
   RedisEndpointAddress:
     Value: !GetAtt ElasticacheCluster.RedisEndpoint.Address
@@ -56,3 +50,6 @@ Outputs:
     Value: !GetAtt ElasticacheCluster.RedisEndpoint.Port
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-RedisEndpointPort'
+
+  RedisEndpoint:
+    Value: !Sub 'redis://${ElasticacheCluster.RedisEndpoint.Address}:${ElasticacheCluster.RedisEndpoint.Port}'


### PR DESCRIPTION
Fixed the following failures..

* ElasticacheCluster AWS::ElastiCache::CacheCluster CREATE_FAILED Encryption feature is not supported for engine REDIS.
* nextflow-elasticache-cluster AWS::CloudFormation::Stack ROLLBACK_IN_PROGRESS Template error: The ConfigurationEndpoint.Port attribute type is not supported for the redis cache cluster engine.
* nextflow-elasticache-cluster AWS::CloudFormation::Stack ROLLBACK_IN_PROGRESS Template error: The ConfigurationEndpoint.Address attribute type is not supported for the redis cache cluster engine.

I was not able to enable transit encryption for Elasticache with Redis. The AWS docs[1] says it supported but I keep getting errors on multiple attempts.  We just leave it unencrypted for now to get things working. We will attempt to encrypt later on.  I do know that encryption is only supported on r6g instances and not r6gd instances so we are gonna switch to use the more common instance.

[1] https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html