### PR TITLE
[IT-3184] optional self hosted redis container

### DIFF
--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -37,3 +37,4 @@ stack_tags:
 
 sceptre_user_data:
   environment: !file src/tower/resources/environment.yaml
+  EnableRedisDocker: false

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -36,3 +36,4 @@ stack_tags:
 
 sceptre_user_data:
   environment: !file src/tower/resources/environment.yaml
+  EnableRedisDocker: true

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -178,6 +178,7 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
+      {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
         # The following container definition is a stop-gap solution for
         # https://sagebionetworks.jira.com/browse/WORKFLOWS-521
         - Name: !Sub '${RedisContainerName}-CheckAOF'
@@ -225,16 +226,19 @@ Resources:
               awslogs-region: !Sub '${AWS::Region}'
               awslogs-group: !Ref TowerTaskLogGroup
               awslogs-stream-prefix: !Ref AwslogsStreamPrefix
+      {%- endif %}
         - Name: !Sub '${CronContainerName}-MigrateDb'
           Image: !Ref CronContainerImage
           Memory: 2000
           Cpu: 0
           Essential: false
+      {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
           Links:
             - !Ref RedisContainerName
           DependsOn:
             - ContainerName: !Ref RedisContainerName
               Condition: START
+      {%- endif %}
           WorkingDirectory: /work
           EntryPoint:
             - /bin/sh
@@ -260,6 +264,7 @@ Resources:
           Image: !Ref CronContainerImage
           Memory: 2000
           Cpu: 0
+      {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
           Links:
             - !Ref RedisContainerName
           DependsOn:
@@ -267,6 +272,7 @@ Resources:
               Condition: START
             - ContainerName: !Sub '${CronContainerName}-MigrateDb'
               Condition: SUCCESS
+      {%- endif %}
           WorkingDirectory: /work
           EntryPoint:
             - /bin/sh


### PR DESCRIPTION
We have setup Elasticache redis in the dev environment.  In order to verify that Elasticache has taken over for the self hosted redis docker instance we need to disable it for the dev environment while still keeping it enabled for the prod environment.  This change allows the tower admin to enable or disable the self hosted redis docker resources per environment.