### PR TITLE
[IT-3184] fix redis deployment

### DIFF
--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -21,7 +21,6 @@ parameters:
   TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
-  RedisContainerImage: 'redis:5.0.8'
   CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
   FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
   BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -74,6 +74,7 @@ Parameters:
     Type: String
     Default: 'NULL'
     Description: Redis connection URL
+{%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
   RedisContainerName:
     Type: String
     Description: (Optional) Name of the container that runs redis
@@ -81,6 +82,7 @@ Parameters:
   RedisContainerImage:
     Type: String
     Description: Redis container docker image, e.g. 'redis:5.0.8'
+{%- endif %}
   CronContainerName:
     Type: String
     Description: (Optional) Name of the cron container
@@ -283,8 +285,13 @@ Resources:
             - Name: MICRONAUT_ENVIRONMENTS
               Value: !If
                 - HasTowerOidcClient
+              {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
                 - prod,redis,cron,workspace,awsbatch-platform,auth-google,auth-oidc
                 - prod,redis,cron,workspace,awsbatch-platform,auth-google
+              {%- else %}
+                - prod,cron,workspace,awsbatch-platform,auth-google,auth-oidc
+                - prod,cron,workspace,awsbatch-platform,auth-google
+              {%- endif %}
             {%- for name, value in sceptre_user_data.environment.items() %}
             - Name: {{ name }}
               Value: {{ value }}
@@ -328,7 +335,9 @@ Resources:
               HostPort: !Ref BackendHostPort
           Essential: false
           Links:
+          {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
             - redis
+          {%- endif %}
             - cron
           WorkingDirectory: /work
           DependsOn:
@@ -340,8 +349,13 @@ Resources:
             - Name: MICRONAUT_ENVIRONMENTS
               Value: !If
                 - HasTowerOidcClient
+              {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
                 - prod,redis,ha,workspace,awsbatch-platform,auth-google,auth-oidc
                 - prod,redis,ha,workspace,awsbatch-platform,auth-google
+              {%- else %}
+                - prod,ha,workspace,awsbatch-platform,auth-google,auth-oidc
+                - prod,ha,workspace,awsbatch-platform,auth-google
+              {%- endif %}
             {%- for name, value in sceptre_user_data.environment.items() %}
             - Name: {{ name }}
               Value: {{ value }}


### PR DESCRIPTION
This fixes commit 69df85d.  Some places in the template refer to `redis` and other places refer to `RedisContainerName` which seem to be the same thing.  We forgot to handle `redis` in commit 69df85d so this is the fix.