### PR TITLE
[IT-3184] Fix nextflow-ecs-service deployment

### DIFF
--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -4,6 +4,8 @@ stack_name: nextflow-ecs-task-definition
 dependencies:
   - infra-dev/nextflow-aurora-mysql.yaml
   - infra-dev/nextflow-efs-file-system.yaml
+  - infra-dev/nextflow-elasticache-cluster.yaml
+
 
 parameters:
   TowerSmtpHost: 'email-smtp.us-east-1.amazonaws.com'

--- a/config/infra-dev/nextflow-elasticache-cluster.yaml
+++ b/config/infra-dev/nextflow-elasticache-cluster.yaml
@@ -4,7 +4,6 @@ stack_name: nextflow-elasticache-cluster
 dependencies:
   - infra-dev/nextflow-vpc.yaml
   - infra-dev/nextflow-ecs-security-group.yaml
-  - infra-dev/nextflow-ecs-cluster.yaml
 
 parameters:
   VpcId: !stack_output_external nextflow-vpc::VPCId

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -287,13 +287,8 @@ Resources:
             - Name: MICRONAUT_ENVIRONMENTS
               Value: !If
                 - HasTowerOidcClient
-              {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
                 - prod,redis,cron,workspace,awsbatch-platform,auth-google,auth-oidc
                 - prod,redis,cron,workspace,awsbatch-platform,auth-google
-              {%- else %}
-                - prod,cron,workspace,awsbatch-platform,auth-google,auth-oidc
-                - prod,cron,workspace,awsbatch-platform,auth-google
-              {%- endif %}
             {%- for name, value in sceptre_user_data.environment.items() %}
             - Name: {{ name }}
               Value: {{ value }}
@@ -353,13 +348,8 @@ Resources:
             - Name: MICRONAUT_ENVIRONMENTS
               Value: !If
                 - HasTowerOidcClient
-              {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
                 - prod,redis,ha,workspace,awsbatch-platform,auth-google,auth-oidc
                 - prod,redis,ha,workspace,awsbatch-platform,auth-google
-              {%- else %}
-                - prod,ha,workspace,awsbatch-platform,auth-google,auth-oidc
-                - prod,ha,workspace,awsbatch-platform,auth-google
-              {%- endif %}
             {%- for name, value in sceptre_user_data.environment.items() %}
             - Name: {{ name }}
               Value: {{ value }}


### PR DESCRIPTION
The nextflow-ecs-service deployment was failing with the following error..
```
ERROR io.micronaut.runtime.Micronaut - Error starting Micronaut server:
Failed to inject value for parameter [redisTopic] of method [setRedisTopic]
of class: io.seqera.tower.service.live.PublishOnlyEventsService
```

Attempt to fix that by doing the following:
* Fix nextflow-elasticache-cluster dependency
* always include `redis` to MICRONAUT_ENVIRONMENTS

clue provided by Seqera in ticket https://support.seqera.io/support/tickets/4165