### PR TITLE
[IT-3184] Elasticache for nextflow tower prod

### DIFF
--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -4,6 +4,7 @@ stack_name: nextflow-ecs-task-definition
 dependencies:
   - infra-prod/nextflow-aurora-mysql.yaml
   - infra-prod/nextflow-efs-file-system.yaml
+  - infra-prod/nextflow-elasticache-cluster.yaml
 
 parameters:
   TowerSmtpHost: 'email-smtp.us-east-1.amazonaws.com'
@@ -12,6 +13,7 @@ parameters:
   TowerSmtpPassword: !ssm 'smtp-password'
   TowerContactEmail: nextflow-admins@sagebase.org
   TowerServerUrl: https://tower.sagebionetworks.org
+  TowerRedisUrl: !stack_output_external nextflow-elasticache-cluster::RedisEndpoint
   TowerJwtSecret: !aws_secrets_manager nextflow-tower-secret/jwt::SecretString::secret
   TowerCryptoSecretkey: !aws_secrets_manager nextflow-tower-secret/crypto::SecretString::secret
   TowerLicense: !aws_secrets_manager nextflow/license::SecretString::license_key
@@ -20,7 +22,6 @@ parameters:
   TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
-  RedisContainerImage: 'redis:5.0.8'
   CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
   FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
   BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
@@ -36,4 +37,4 @@ stack_tags:
 
 sceptre_user_data:
   environment: !file src/tower/resources/environment.yaml
-  EnableRedisDocker: true
+  EnableRedisDocker: false

--- a/config/infra-prod/nextflow-elasticache-cluster.yaml
+++ b/config/infra-prod/nextflow-elasticache-cluster.yaml
@@ -1,0 +1,17 @@
+template:
+  path: nextflow-elasticache-cluster.yaml
+stack_name: nextflow-elasticache-cluster
+dependencies:
+  - infra-dev/nextflow-vpc.yaml
+  - infra-dev/nextflow-ecs-security-group.yaml
+
+parameters:
+  VpcId: !stack_output_external nextflow-vpc::VPCId
+  VpcSubnetIDs:
+    - !stack_output_external nextflow-vpc::PrivateSubnet1
+    - !stack_output_external nextflow-vpc::PrivateSubnet2
+    - !stack_output_external nextflow-vpc::PrivateSubnet3
+  EcsSecurityGroupId: !stack_output_external nextflow-ecs-security-group::SecurityGroupId
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}


### PR DESCRIPTION
Switch nextflow tower from using a self hosted redis docker to AWS elasticache with redis service.  This has already been setup in the AWS nexflow-dev account, this is to enable it for the AWS nextflow-prod account.