### PR TITLE
[IT-3184] Reduce EFS throughput config

### DIFF
--- a/config/infra-prod/nextflow-efs-file-system.yaml
+++ b/config/infra-prod/nextflow-efs-file-system.yaml
@@ -13,7 +13,6 @@ parameters:
   EcsSecurityGroupId: !stack_output_external nextflow-ecs-security-group::SecurityGroupId
   NextflowTowerConfigBucketArn: !stack_output_external nextflow-tower-config::BucketArn
   ThroughputMode: provisioned
-  ProvisionedThroughputInMibps: "1024"
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}


### PR DESCRIPTION
Now that we are using Elasticache Redis instead of a self hosted docker Redis container (PR #266) we can reduce the EFS throughput mode to reduce EFS cost.