### PR TITLE
[IBCDPE-764] Adds External User to `iatlas-project`

### DIFF
--- a/config/projects-prod/iatlas-project.yaml
+++ b/config/projects-prod/iatlas-project.yaml
@@ -21,6 +21,7 @@ parameters:
     - "{{stack_group_config.tower_viewer_arn_prefix}}/dbortone@email.unc.edu"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/steven_vensko@med.unc.edu"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/cheimann@isbscience.org"
+    - "{{stack_group_config.tower_viewer_arn_prefix}}/clarisse.lau@isbscience.org"
   AccountAdminArns:
     - "{{stack_group_config.sso_admin_role.arn}}"
     - !stack_output_external sagebase-github-oidc-workflows-prod-nextflow-infra::ProviderRoleArn

--- a/templates/nextflow-tower-config-bucket.yaml
+++ b/templates/nextflow-tower-config-bucket.yaml
@@ -68,6 +68,7 @@ Resources:
                 - "*@sagebase.org"
                 - "*@sagebionetworks.org"
                 - "cheimann@isbscience.org"
+                - "clarisse.lau@isbscience.org"
           trustedEmails:
             - "benjamin_vincent@med.unc.edu"
             - "dbortone@email.unc.edu"


### PR DESCRIPTION
This PR adds an external user from ISB to the `iatlas-project` Tower workspace. I am requesting to merge this directly into `prod` so that the user can have access right away.