### PR TITLE
[IT-2360] Setup IAM roles for tower

### DIFF
--- a/config/common/nextflow-ecs-service-shared.yaml
+++ b/config/common/nextflow-ecs-service-shared.yaml
@@ -1,0 +1,6 @@
+template:
+  path: nextflow-ecs-service-shared.yaml
+stack_name: nextflow-ecs-service-shared
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/src/tower/resources/environment.yaml
+++ b/src/tower/resources/environment.yaml
@@ -26,3 +26,4 @@ TOWER_OIDC_TOKEN_IMPORT: "!If [ HasTowerOidcClient, !Ref TowerOidcTokenImport, !
 TOWER_ROOT_USERS: "!If [ HasTowerRootUsers, !Join [',', !Ref TowerRootUsers], !Ref AWS::NoValue]"
 TOWER_USER_WORKSPACE_ENABLED: "!Ref 'TowerUserWorkspace'"
 TOWER_CONFIG_FILE: "!Sub '${EfsVolumeMountPath}/${TowerConfigFileName}'"
+TOWER_ALLOW_INSTANCE_CREDENTIALS: "true"

--- a/templates/nextflow-ecs-service-shared.yaml
+++ b/templates/nextflow-ecs-service-shared.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Shared resources Nextflow Tower ECS Service
+
+Resources:
+  EcsServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+              - ecs.amazonaws.com
+          Action:
+            - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: ecs-service
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+              - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
+              - elasticloadbalancing:DeregisterTargets
+              - elasticloadbalancing:Describe*
+              - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+              - elasticloadbalancing:RegisterTargets
+              - ec2:Describe*
+              - ec2:AuthorizeSecurityGroupIngress
+            Resource: '*'
+
+Outputs:
+  EcsServiceRoleArn:
+    Value: !GetAtt EcsServiceRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsServiceRoleArn'

--- a/templates/nextflow-ecs-service.yaml
+++ b/templates/nextflow-ecs-service.yaml
@@ -51,33 +51,6 @@ Parameters:
 
 Resources:
 
-  EcsServiceRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-              - ecs.amazonaws.com
-          Action:
-            - sts:AssumeRole
-      Path: /
-      Policies:
-      - PolicyName: ecs-service
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-              - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
-              - elasticloadbalancing:DeregisterTargets
-              - elasticloadbalancing:Describe*
-              - elasticloadbalancing:RegisterInstancesWithLoadBalancer
-              - elasticloadbalancing:RegisterTargets
-              - ec2:Describe*
-              - ec2:AuthorizeSecurityGroupIngress
-            Resource: '*'
-
   EcsAlbSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -125,7 +98,6 @@ Resources:
 
   EcsAlbListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
-    DependsOn: EcsServiceRole
     Properties:
       DefaultActions:
       - Type: forward
@@ -148,7 +120,8 @@ Resources:
       CapacityProviderStrategy:
         - CapacityProvider: !Ref TowerCapacityProviderName
           Weight: 1
-      Role: !Ref EcsServiceRole
+      Role:
+        'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-ecs-service-shared-EcsServiceRoleArn
       LoadBalancers:
       - ContainerName: !Ref TowerUIContainerName
         ContainerPort: !Ref TowerUIContainerPort
@@ -214,8 +187,3 @@ Outputs:
     Value: !GetAtt EcsApplicationLoadBalancer.CanonicalHostedZoneID
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-LoadBalancerCanonicalHostedZoneID'
-
-  EcsServiceRoleArn:
-    Value: !GetAtt EcsServiceRole.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsServiceRoleArn'

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -141,6 +141,39 @@ Resources:
               Service:
                 - ecs-tasks.amazonaws.com
 
+  TowerRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      ManagedPolicyArns:
+        - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-forge-iam-policy-NextFlowForgePolicyArn
+        - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-launch-iam-policy-NextFlowLaunchPolicyArn
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service: eks.amazonaws.com
+            Action: sts:AssumeRole
+          - Sid: AllowEc2AssumeRole
+            Effect: Allow
+            Principal:
+              AWS: !Ref AccountAdminArns
+            Action: sts:AssumeRole
+          - Sid: AllowEcsServiceRole2AssumeRole
+            Effect: Allow
+            Principal:
+              AWS:
+                - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-ecs-service-shared-EcsServiceRoleArn
+            Action: sts:AssumeRole
+
   TowerForgeBatchHeadJobPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -585,6 +618,11 @@ Outputs:
     Value: !GetAtt TowerForgeServiceRole.Arn
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceRoleArn"
+
+  TowerRoleArn:
+    Value: !GetAtt TowerRole.Arn
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerRoleArn"
 
   TowerForgeBatchHeadJobRole:
     Value: !Ref TowerForgeBatchHeadJobRole


### PR DESCRIPTION
This is a 2nd attempt at PR #229 which was reverted in commit 698a3ffbc. The first attempt failed because AWS wanted to re-create the ECS service without first deleting the existing resource therefore cloudformation responded with this error..

```
TowerService AWS::ECS::Service UPDATE_FAILED Resource handler returned message:
"Resource of type 'AWS::ECS::Service' with identifier 'Nextflow-Tower-Service'
already exists."
```

This PR will require some manual intervention to help guide it thru.