### PR TITLE
Add external collaborator's ARN to project bucket access list

### DIFF
--- a/config/projects-prod/mc2-histoqc-project.yaml
+++ b/config/projects-prod/mc2-histoqc-project.yaml
@@ -10,6 +10,7 @@ parameters:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/adam.taylor@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/chelsea.nayan@sagebase.org'
+    - 'arn:aws:iam::136990331731:role/jjaco34_S3FullAccess'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'


### PR DESCRIPTION
This PR adds the ARN of Jackson Jacobs, our collaborator at Emory on the MC2 Digital Pathology QC supplement, to the relevant bucket so that they can access results directly.