### PR TITLE
Add Phil Snyder to MC2 HistoQC project bucket

### DIFF
--- a/config/projects-prod/mc2-histoqc-project.yaml
+++ b/config/projects-prod/mc2-histoqc-project.yaml
@@ -10,6 +10,7 @@ parameters:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/adam.taylor@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/chelsea.nayan@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/phil.snyder@sagebase.org'
     - 'arn:aws:iam::136990331731:role/jjaco34_S3FullAccess'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:


### PR DESCRIPTION
This PR gives @philerooski access to the Nextflow buckets for the MC2 HistoQC tower project to facilitate the following ticket: https://sagebionetworks.jira.com/browse/IBCDPE-833