### PR TITLE
Reverts Fusion Compute Environment Changes

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -15,7 +15,7 @@ import yaml  # type: ignore
 from sagetasks.nextflowtower.client import TowerClient  # type: ignore
 
 # Increment this version when updating compute environments
-CE_VERSION = "v13"
+CE_VERSION = "v12"
 
 REGION = "us-east-1"
 ORG_NAME = "Sage Bionetworks"
@@ -661,7 +661,7 @@ class TowerWorkspace:
                     "credentials": None,
                     "environment": None,
                     "executionRole": self.stack["TowerForgeBatchExecutionRoleArn"],
-                    "fusion2Enabled": True,
+                    "fusion2Enabled": False,
                     "headJobCpus": 8,
                     "headJobMemoryMb": 15000,
                     "headJobRole": self.stack["TowerForgeBatchHeadJobRoleArn"],


### PR DESCRIPTION
I have decided to revert the changes I made to enable Fusion V2 in `dev` compute environments for now. After a conversation with Seqera, I learned that many other configuration changes need to be made to enable this which I will continue researching and documenting. As it stands, workflows are failing in `dev` due to Fusion being enabled without the other configuration settings.