### PR TITLE
Run Sceptre with prune option

### DIFF
--- a/.github/workflows/rw-deploy.yaml
+++ b/.github/workflows/rw-deploy.yaml
@@ -53,17 +53,17 @@ jobs:
       - name: Deploy common configuration
         run: >
           pipenv run sceptre --var-file=src/sceptre/variables/${{ inputs.sceptre-suffix }}.yaml
-          launch common --yes
+          launch common --yes --prune
 
       - name: Deploy infrastructure configuration
         run: >
           pipenv run sceptre --var-file=src/sceptre/variables/${{ inputs.sceptre-suffix }}.yaml
-          launch infra-${{ inputs.sceptre-suffix }} --yes
+          launch infra-${{ inputs.sceptre-suffix }} --yes --prune
 
       - name: Deploy projects configuration
         run: >
           pipenv run sceptre --var-file=src/sceptre/variables/${{ inputs.sceptre-suffix }}.yaml
-          launch projects-${{ inputs.sceptre-suffix }} --yes
+          launch projects-${{ inputs.sceptre-suffix }} --yes --prune
 
       - name: Wait for Nextflow Tower to be up
         uses: nev7n/wait_for_response@v1


### PR DESCRIPTION
Sceptre should run with prune[1] option in CI workflow to allow it to remove stacks that are marked `obsolete`.

[1] https://docs.sceptre-project.org/latest/docs/cli.html#cmdoption-sceptre-launch-p