### PR TITLE
update owner of jared hendrickson project, add Jaclyn Beck as user

### DIFF
--- a/config/projects-ampad/jared-hendrickson-project.yaml
+++ b/config/projects-ampad/jared-hendrickson-project.yaml
@@ -8,8 +8,8 @@ dependencies:
 parameters:
   S3ReadWriteAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/william.poehlman@sagebase.org'
-    - '{{stack_group_config.tower_viewer_arn_prefix}}/jared.hendrickson@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jaclyn.beck@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'
@@ -21,4 +21,4 @@ parameters:
 stack_tags:
   Department: NDR
   Project: amp-ad
-  OwnerEmail: jared.hendrickson@sagebase.org
+  OwnerEmail: william.poehlman@sagebase.org


### PR DESCRIPTION
Due to Jared Hendrickson's departure from Sage, I am updating his tower account to make myself the owner. I am also adding Jaclyn Beck as a user so that she can refer to previous workflow runs for provenance/configuration details. We do not want to delete this account as we need to refer to previous workflow runs for certain projects and there are still important files on the associated Tower buckets. 