### PR TITLE
[Workflows-549] Using IAM role in Tower to authenticate AWS services 

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -536,7 +536,6 @@ class TowerWorkspace:
                 "provider": "aws",
                 "keys": {
                     "accessKey": credentials["aws_access_key_id"],
-                    # "secretKey": credentials["aws_secret_access_key"],
                     "assumeRoleArn": self.stack["TowerRoleArn"],
                 },
                 "description": f"Credentials for {self.stack_name}",

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -536,7 +536,7 @@ class TowerWorkspace:
                 "provider": "aws",
                 "keys": {
                     "accessKey": credentials["aws_access_key_id"],
-                    #"secretKey": credentials["aws_secret_access_key"],
+                    # "secretKey": credentials["aws_secret_access_key"],
                     "assumeRoleArn": self.stack["TowerRoleArn"],
                 },
                 "description": f"Credentials for {self.stack_name}",

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -528,7 +528,7 @@ class TowerWorkspace:
                 assert cred["deleted"] is None
                 return cred["id"]
         # Otherwise, create a new credentials entry for the project
-        secret_arn = self.stack["TowerForgeServiceUserAccessKeySecretArn"]
+        secret_arn = self.stack["TowerRoleArn"]
         credentials = self.org.aws.get_secret_value(secret_arn)
         data = {
             "credentials": {
@@ -536,8 +536,8 @@ class TowerWorkspace:
                 "provider": "aws",
                 "keys": {
                     "accessKey": credentials["aws_access_key_id"],
-                    "secretKey": credentials["aws_secret_access_key"],
-                    "assumeRoleArn": self.stack["TowerForgeServiceRoleArn"],
+                    #"secretKey": credentials["aws_secret_access_key"],
+                    "assumeRoleArn": self.stack["TowerRoleArn"],
                 },
                 "description": f"Credentials for {self.stack_name}",
             }

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -288,6 +288,7 @@ Resources:
             - !GetAtt TowerForgeBatchHeadJobRole.Arn
             - !GetAtt TowerForgeBatchWorkJobRole.Arn
             - !GetAtt TowerForgeServiceRole.Arn
+            - !GetAtt TowerRole.Arn
             - !Join
               - ","
               - !Ref AccountAdminArns
@@ -374,6 +375,7 @@ Resources:
                 - !GetAtt TowerForgeServiceRole.Arn
                 - !GetAtt TowerForgeBatchHeadJobRole.Arn
                 - !GetAtt TowerForgeBatchWorkJobRole.Arn
+                - !GetAtt TowerRole.Arn
             Action:
               - "s3:GetBucketLocation"
               - "s3:ListBucket"
@@ -511,6 +513,7 @@ Resources:
                 - !GetAtt TowerForgeServiceRole.Arn
                 - !GetAtt TowerForgeBatchHeadJobRole.Arn
                 - !GetAtt TowerForgeBatchWorkJobRole.Arn
+                - !GetAtt TowerRole.Arn
             Action:
               - "s3:GetBucketLocation"
               - "s3:ListBucket"


### PR DESCRIPTION
Problem: 

Currently, the IAM user is used by the Tower to access AWS. 

Solution:

Enable access to Tower workspace using an IAM Role
