### PR TITLE
[IT-3968] remove iam users

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -528,14 +528,14 @@ class TowerWorkspace:
                 assert cred["deleted"] is None
                 return cred["id"]
         # Otherwise, create a new credentials entry for the project
-        secret_arn = self.stack["TowerRoleArn"]
-        credentials = self.org.aws.get_secret_value(secret_arn)
+        # secret_arn = self.stack["TowerRoleArn"]
+        # credentials = self.org.aws.get_secret_value(secret_arn)
         data = {
             "credentials": {
                 "name": self.stack_name,
                 "provider": "aws",
                 "keys": {
-                    "accessKey": credentials["aws_access_key_id"],
+                    # "accessKey": credentials["aws_access_key_id"],
                     "assumeRoleArn": self.stack["TowerRoleArn"],
                 },
                 "description": f"Credentials for {self.stack_name}",

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -173,6 +173,11 @@ Resources:
               AWS:
                 - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-ecs-service-shared-EcsServiceRoleArn
             Action: sts:AssumeRole
+  TowerRoleProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref TowerRole
 
   TowerForgeBatchHeadJobPolicy:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
Problem:

The AWS credentials can't be populated with IAM role arn. And `get_secret_value` function does not work with IAM role arn.  Ideally, after converting to using IAM role, we no longer need to use accessKeys as the AWS credential of the Tower workspaces. Instead, we use AWS arn (see this [instruction](https://docs.seqera.io/platform/23.4.0/enterprise/advanced-topics/use-iam-role#:~:text=Log%20in%20to%20Seqera%20and%20create%20a%20new%20AWS%20credential.%20You%20are%20now%20prompted%20for%20an%20AWS%20arn%20instead%20of%20access%20keys.))

Solution: 

As the [Seqera's instruction](https://docs.seqera.io/platform/23.4.0/enterprise/advanced-topics/use-iam-role#:~:text=Create%20an%20instance%20profile%3A), an instance profile should be created and attached with the IAM role. My understanding is that creating InstanceProfile for the role would allow EC2 to receive the IAM role credential when it assumes the role. 

Testing:
The credential can be saved in Tower right now, but another error: {'message': "Cannot determine region of bucket 'example-dev-project-tower-scratch'"} popped up when generating the computation environment. The errors lie in these [lines](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/blob/ee144038319caf89e095c6cf6ca235aa1aa1540e/bin/configure-tower-projects.py#L725C1-L730C1)