### PR TITLE
Revert WORKFLOWS-549

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -528,7 +528,7 @@ class TowerWorkspace:
                 assert cred["deleted"] is None
                 return cred["id"]
         # Otherwise, create a new credentials entry for the project
-        secret_arn = self.stack["TowerRoleArn"]
+        secret_arn = self.stack["TowerForgeServiceUserAccessKeySecretArn"]
         credentials = self.org.aws.get_secret_value(secret_arn)
         data = {
             "credentials": {
@@ -536,7 +536,8 @@ class TowerWorkspace:
                 "provider": "aws",
                 "keys": {
                     "accessKey": credentials["aws_access_key_id"],
-                    "assumeRoleArn": self.stack["TowerRoleArn"],
+                    "secretKey": credentials["aws_secret_access_key"],
+                    "assumeRoleArn": self.stack["TowerForgeServiceRoleArn"],
                 },
                 "description": f"Credentials for {self.stack_name}",
             }

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -288,7 +288,6 @@ Resources:
             - !GetAtt TowerForgeBatchHeadJobRole.Arn
             - !GetAtt TowerForgeBatchWorkJobRole.Arn
             - !GetAtt TowerForgeServiceRole.Arn
-            - !GetAtt TowerRole.Arn
             - !Join
               - ","
               - !Ref AccountAdminArns
@@ -375,7 +374,6 @@ Resources:
                 - !GetAtt TowerForgeServiceRole.Arn
                 - !GetAtt TowerForgeBatchHeadJobRole.Arn
                 - !GetAtt TowerForgeBatchWorkJobRole.Arn
-                - !GetAtt TowerRole.Arn
             Action:
               - "s3:GetBucketLocation"
               - "s3:ListBucket"
@@ -513,7 +511,6 @@ Resources:
                 - !GetAtt TowerForgeServiceRole.Arn
                 - !GetAtt TowerForgeBatchHeadJobRole.Arn
                 - !GetAtt TowerForgeBatchWorkJobRole.Arn
-                - !GetAtt TowerRole.Arn
             Action:
               - "s3:GetBucketLocation"
               - "s3:ListBucket"


### PR DESCRIPTION
This PR reverts WORKFLOWS-549-remove-IAMusers since the commit breaks the deployment pipeline