### PR TITLE
[IBCDPE-955] Upgrade to latest Tower Version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v23.1.4
+tower_version: v23.4.0
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
This PR upgrades Tower/Seqera Platform to the latest [version](https://docs.seqera.io/platform/23.4.0/enterprise/release_notes/changelog).