### PR TITLE
Reverts Tower Version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v23.4.0
+tower_version: v23.1.4
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
There were some workspace access changes that were not merged into `prod` prior to our upgrade attempt. In order to make sure we aren't blocking anyone, we should revert this change and then merge `dev` into `prod`.