### PR TITLE
Seqera-Directed Changes for 23.4.3 Update

### DIFF
--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -6,12 +6,11 @@ dependencies:
   - infra-dev/nextflow-efs-file-system.yaml
   - infra-dev/nextflow-elasticache-cluster.yaml
 
-
 parameters:
-  TowerSmtpHost: 'email-smtp.us-east-1.amazonaws.com'
-  TowerSmtpPort: '587'
-  TowerSmtpUser: !ssm 'smtp-username'
-  TowerSmtpPassword: !ssm 'smtp-password'
+  TowerSmtpHost: "email-smtp.us-east-1.amazonaws.com"
+  TowerSmtpPort: "587"
+  TowerSmtpUser: !ssm "smtp-username"
+  TowerSmtpPassword: !ssm "smtp-password"
   TowerContactEmail: nextflow-admins@sagebase.org
   TowerServerUrl: https://tower-dev.sagebionetworks.org
   TowerRedisUrl: !stack_output_external nextflow-elasticache-cluster::RedisEndpoint
@@ -23,19 +22,19 @@ parameters:
   TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
-  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
-  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
-  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
+  CronContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
+  FrontendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}"
+  BackendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
+  MigrateDBContainerImage: "cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}"
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
-  EfsVolumeMountPath: '/efs'
-  TowerUserWorkspace: 'false'
+  EfsVolumeMountPath: "/efs"
+  TowerUserWorkspace: "false"
   TowerRootUsers:
     - thomas.yu@sagebase.org
     - khai.do@sagebase.org
-  TowerConfigFileName: 'tower.yaml'
+  TowerConfigFileName: "tower.yaml"
 
-stack_tags:
-  {{stack_group_config.default_stack_tags}}
+stack_tags: { { stack_group_config.default_stack_tags } }
 
 sceptre_user_data:
   environment: !file src/tower/resources/environment.yaml

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -7,10 +7,10 @@ dependencies:
   - infra-prod/nextflow-elasticache-cluster.yaml
 
 parameters:
-  TowerSmtpHost: 'email-smtp.us-east-1.amazonaws.com'
-  TowerSmtpPort: '587'
-  TowerSmtpUser: !ssm 'smtp-username'
-  TowerSmtpPassword: !ssm 'smtp-password'
+  TowerSmtpHost: "email-smtp.us-east-1.amazonaws.com"
+  TowerSmtpPort: "587"
+  TowerSmtpUser: !ssm "smtp-username"
+  TowerSmtpPassword: !ssm "smtp-password"
   TowerContactEmail: nextflow-admins@sagebase.org
   TowerServerUrl: https://tower.sagebionetworks.org
   TowerRedisUrl: !stack_output_external nextflow-elasticache-cluster::RedisEndpoint
@@ -22,18 +22,18 @@ parameters:
   TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
-  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
-  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
-  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
+  CronContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
+  FrontendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}"
+  BackendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
+  MigrateDBContainerImage: "cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}"
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
-  EfsVolumeMountPath: '/efs'
-  TowerUserWorkspace: 'false'
+  EfsVolumeMountPath: "/efs"
+  TowerUserWorkspace: "false"
   TowerRootUsers:
     - thomas.yu@sagebase.org
-  TowerConfigFileName: 'tower.yaml'
+  TowerConfigFileName: "tower.yaml"
 
-stack_tags:
-  {{stack_group_config.default_stack_tags}}
+stack_tags: { { stack_group_config.default_stack_tags } }
 
 sceptre_user_data:
   environment: !file src/tower/resources/environment.yaml

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -83,6 +83,15 @@ Parameters:
     Type: String
     Description: Redis container docker image, e.g. 'redis:5.0.8'
 {%- endif %}
+  MigrateDBContainerName:
+    Type: String
+    Description: (Optional) Name of the migrate-db container
+    Default: migrate-db
+  MigrateDBContainerImage:
+    Type: String
+    Description: >
+      (Optional) migrate-db container docker image,
+      e.g. 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:v23.4.3'
   CronContainerName:
     Type: String
     Description: (Optional) Name of the cron container
@@ -180,6 +189,21 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
+        - image: !Ref RedisContainerImage
+          repositoryCredentials:
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
+        - image: !Ref MigrateDBContainerImage
+          repositoryCredentials:
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'      
+        - image: !Ref FrontendContainerImage
+          repositoryCredentials:
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'        
+        - image: !Ref BackendContainerImage
+          repositoryCredentials:
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
+        - image: !Ref CronContainerImage
+          repositoryCredentials:
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
       {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
         # The following container definition is a stop-gap solution for
         # https://sagebionetworks.jira.com/browse/WORKFLOWS-521
@@ -229,8 +253,8 @@ Resources:
               awslogs-group: !Ref TowerTaskLogGroup
               awslogs-stream-prefix: !Ref AwslogsStreamPrefix
       {%- endif %}
-        - Name: !Sub '${CronContainerName}-MigrateDb'
-          Image: !Ref CronContainerImage
+        - Name: !Sub '${MigrateDBContainerName}'
+          Image: !Ref MigrateDBContainerImage
           Memory: 2000
           Cpu: 0
           Essential: false
@@ -275,7 +299,7 @@ Resources:
             - ContainerName: !Ref RedisContainerName
               Condition: START
       {%- endif %}
-            - ContainerName: !Sub '${CronContainerName}-MigrateDb'
+            - ContainerName: !Sub '${MigrateDBContainerName}'
               Condition: SUCCESS
           WorkingDirectory: /work
           EntryPoint:

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -100,7 +100,7 @@ Parameters:
     Type: String
     Description: >
       (Optional) Cron container docker image,
-      e.g. '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.0'
+      e.g. 'cr.seqera.io/private/nf-tower-enterprise/backend:v21.06.0'
   FrontendContainerName:
     Type: String
     Description: (Optional) Name of the container that runs the tower ui
@@ -109,7 +109,7 @@ Parameters:
     Type: String
     Description: >
       Frontend container docker image,
-      e.g. '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v21.06.0'
+      e.g. 'cr.seqera.io/private/nf-tower-enterprise/frontend:v21.06.0'
   FrontendContainerPort:
     Type: Number
     Description: (Optional) Port to open in frontend container
@@ -126,7 +126,7 @@ Parameters:
     Type: String
     Description: >
       Backend container docker image,
-      e.g. '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.0'
+      e.g. 'cr.seqera.io/private/nf-tower-enterprise/backend:v21.06.0'
   BackendContainerPort:
     Type: Number
     Description: (Optional) Port to open in backend container
@@ -194,10 +194,10 @@ Resources:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
         - image: !Ref MigrateDBContainerImage
           repositoryCredentials:
-            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'      
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
         - image: !Ref FrontendContainerImage
           repositoryCredentials:
-            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'        
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
         - image: !Ref BackendContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -253,7 +253,7 @@ Resources:
               awslogs-group: !Ref TowerTaskLogGroup
               awslogs-stream-prefix: !Ref AwslogsStreamPrefix
       {%- endif %}
-        - Name: !Sub '${MigrateDBContainerName}'
+        - Name: !Ref MigrateDBContainerName
           Image: !Ref MigrateDBContainerImage
           Memory: 2000
           Cpu: 0
@@ -299,7 +299,7 @@ Resources:
             - ContainerName: !Ref RedisContainerName
               Condition: START
       {%- endif %}
-            - ContainerName: !Sub '${MigrateDBContainerName}'
+            - ContainerName: !Ref MigrateDBContainerName
               Condition: SUCCESS
           WorkingDirectory: /work
           EntryPoint:


### PR DESCRIPTION
This PR makes necessary changes for the latest version of Tower (Seqera Platform) to be able to deploy successfully.

Changes Include:
- Using the new Seqera container registry `cr.seqera.io/private/nf-tower-enterprise` and adding needed authentication credentials
- Adding a new container and step to the ECS task definition for database migration
- Adding configuration to ensure that the database migration occurs before the rest of the steps