### PR TITLE
Fixes Redis Config

### DIFF
--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -26,6 +26,7 @@ parameters:
   FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
   BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
   MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
+  RedisContainerImage: 'cr.seqera.io/public/redis:5.0.8'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerUserWorkspace: 'false'

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -26,6 +26,7 @@ parameters:
   FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
   BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
   MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
+  RedisContainerImage: 'cr.seqera.io/public/redis:5.0.8'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerUserWorkspace: 'false'

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -189,11 +189,6 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
-        {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
-        - image: !Ref RedisContainerImage
-          repositoryCredentials:
-            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        {%- endif %}
         - image: !Ref MigrateDBContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -189,9 +189,11 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
+        {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
         - image: !Ref RedisContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
+        {%- endif %}
         - image: !Ref MigrateDBContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'


### PR DESCRIPTION
The last deployment [failed](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/actions/runs/9604259386/job/26489377669) due to an issue with the `RedisContainerImage` configuration. 

We haven't been using the steps involving redis in our deployment with this [variable](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/blob/1787a9e4d970b4871db31937cd6b2c0c5d06ea10/config/infra-dev/nextflow-ecs-task-definition.yaml#L42) being set to `false`.

I added the Seqera-hosted `redis` image as `RedisContainerImage` in case we need to enable it. Right now it is unclear to me if it needs to be enabled or not.

I also removed the credential configuration for `RedisContainerImage` in the ECS template because it is a public container (this is what was causing the error - a reference to `RedisContainerImage` when it wasn't defined.