### PR TITLE
Adds name to ContainerDefinitions

### DIFF
--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -189,16 +189,20 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
-        - image: !Ref MigrateDBContainerImage
+        - Name: !Ref MigrateDBContainerName
+          Image: !Ref MigrateDBContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        - image: !Ref FrontendContainerImage
+        - Name: !Ref FrontendContainerName
+          Image: !Ref FrontendContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        - image: !Ref BackendContainerImage
+        - Name: !Ref BackendContainerName
+          Image: !Ref BackendContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        - image: !Ref CronContainerImage
+        - Name: !Ref CronContainerName
+          Image: !Ref CronContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
       {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}


### PR DESCRIPTION
The last PR (#322) did get us past that error. But I realized while deploying that we are [missing](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/actions/runs/9617016870/job/26527875554#step:9:106) the requried `Name` parameter from our new `ContainerDefinition` configurations.

This PR adds those missing `Name` values.