### PR TITLE
remove CronContainer from ContainerDefinitions  config

### DIFF
--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -201,10 +201,6 @@ Resources:
           Image: !Ref BackendContainerImage
           RepositoryCredentials:
             CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        - Name: !Ref CronContainerName
-          Image: !Ref CronContainerImage
-          RepositoryCredentials:
-            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
       {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
         # The following container definition is a stop-gap solution for
         # https://sagebionetworks.jira.com/browse/WORKFLOWS-521


### PR DESCRIPTION
This PR removes `CronContainer` from the `ContainerDefinitions` config. This is because it uses the same container image as the backend and the configurations [must be unique](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/actions/runs/9617403116/job/26529103452#step:9:106).