### PR TITLE
Adds Role ARN for ECR Access

### DIFF
--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -183,7 +183,7 @@ Resources:
   TowerTask:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      ExecutionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
+      executionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
       NetworkMode: bridge
       Volumes:
         - Name: !Ref EfsVolumeName

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -183,6 +183,7 @@ Resources:
   TowerTask:
     Type: AWS::ECS::TaskDefinition
     Properties:
+      ExecutionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
       NetworkMode: bridge
       Volumes:
         - Name: !Ref EfsVolumeName

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -183,7 +183,7 @@ Resources:
   TowerTask:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      executionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
+      ExecutionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
       NetworkMode: bridge
       Volumes:
         - Name: !Ref EfsVolumeName


### PR DESCRIPTION
The latest deployment threw this error:

```
Private repository authentication requires that the task definition specify a value for executionRoleArn
```

Based on AWS [docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/example_task_definitions.html), it looks like that ARN needs to point to an IAM role with the managed `AmazonECSTaskExecutionRolePolicy` attached to it. So I created that new role `EcsTaskExecutionRole` and provided the arn here.

Note: I have only added this role to dev, so we will need to create it in prod too if this works.