### PR TITLE
[IBCDPE-999] Upgrade Nextflow Tower to Seqera Platform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,13 @@ The following secrets were created in all AWS accounts (including `strides-ampad
 - `nextflow/ghcr_service_acct`: The GHCR service account credentials for the Wave service
 - `nextflow/quayio_service_acct`: The Quay.io service account credentials for the Wave service
 
+## Deployment Testing
+
+After a new deployment has successfully completed, it is important to ensure things are working as expected by doing the following:
+
+1. Launch a simple workflow such as `nextflow-io/hello` from the UI using both `spot` and `on-demand` compute environments.
+1. Run the `demo.py` [script](https://github.com/Sage-Bionetworks-Workflows/py-orca/blob/main/demo.py) from the `py-orca` repository. Make sure that your connection URI environment variable points to the correct URL and workspace. This will check that the API is working as expected and that individual workspaces are able to access their associated S3 buckets.
+
 ## Additional Notes
 
 - The CIDR ranges of IP addresses specifies in the VPC configurations were added to the [Sage VPN](https://sagebionetworks.jira.com/wiki/spaces/IT/pages/352976898/Sage+VPN) table.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v23.1.4
+tower_version: v23.4.3
 default_stack_tags:
   Department: IBC
   Project: Infrastructure

--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -34,7 +34,7 @@ parameters:
     - khai.do@sagebase.org
   TowerConfigFileName: "tower.yaml"
 
-stack_tags: 
+stack_tags:
   {{stack_group_config.default_stack_tags}}
 
 sceptre_user_data:

--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -26,7 +26,6 @@ parameters:
   FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
   BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
   MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
-  # RedisContainerImage: 'cr.seqera.io/public/redis:5.0.8'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerUserWorkspace: 'false'

--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -7,10 +7,10 @@ dependencies:
   - infra-dev/nextflow-elasticache-cluster.yaml
 
 parameters:
-  TowerSmtpHost: "email-smtp.us-east-1.amazonaws.com"
-  TowerSmtpPort: "587"
-  TowerSmtpUser: !ssm "smtp-username"
-  TowerSmtpPassword: !ssm "smtp-password"
+  TowerSmtpHost: 'email-smtp.us-east-1.amazonaws.com'
+  TowerSmtpPort: '587'
+  TowerSmtpUser: !ssm 'smtp-username'
+  TowerSmtpPassword: !ssm 'smtp-password'
   TowerContactEmail: nextflow-admins@sagebase.org
   TowerServerUrl: https://tower-dev.sagebionetworks.org
   TowerRedisUrl: !stack_output_external nextflow-elasticache-cluster::RedisEndpoint
@@ -22,17 +22,17 @@ parameters:
   TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
-  CronContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
-  FrontendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}"
-  BackendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
-  MigrateDBContainerImage: "cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}"
+  CronContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
+  FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
+  BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
+  MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
-  EfsVolumeMountPath: "/efs"
-  TowerUserWorkspace: "false"
+  EfsVolumeMountPath: '/efs'
+  TowerUserWorkspace: 'false'
   TowerRootUsers:
     - thomas.yu@sagebase.org
     - khai.do@sagebase.org
-  TowerConfigFileName: "tower.yaml"
+  TowerConfigFileName: 'tower.yaml'
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}

--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -6,12 +6,11 @@ dependencies:
   - infra-dev/nextflow-efs-file-system.yaml
   - infra-dev/nextflow-elasticache-cluster.yaml
 
-
 parameters:
-  TowerSmtpHost: 'email-smtp.us-east-1.amazonaws.com'
-  TowerSmtpPort: '587'
-  TowerSmtpUser: !ssm 'smtp-username'
-  TowerSmtpPassword: !ssm 'smtp-password'
+  TowerSmtpHost: "email-smtp.us-east-1.amazonaws.com"
+  TowerSmtpPort: "587"
+  TowerSmtpUser: !ssm "smtp-username"
+  TowerSmtpPassword: !ssm "smtp-password"
   TowerContactEmail: nextflow-admins@sagebase.org
   TowerServerUrl: https://tower-dev.sagebionetworks.org
   TowerRedisUrl: !stack_output_external nextflow-elasticache-cluster::RedisEndpoint
@@ -23,19 +22,19 @@ parameters:
   TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
-  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
-  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
-  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
+  CronContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
+  FrontendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}"
+  BackendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
+  MigrateDBContainerImage: "cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}"
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
-  EfsVolumeMountPath: '/efs'
-  TowerUserWorkspace: 'false'
+  EfsVolumeMountPath: "/efs"
+  TowerUserWorkspace: "false"
   TowerRootUsers:
     - thomas.yu@sagebase.org
     - khai.do@sagebase.org
-  TowerConfigFileName: 'tower.yaml'
+  TowerConfigFileName: "tower.yaml"
 
-stack_tags:
-  {{stack_group_config.default_stack_tags}}
+stack_tags: { { stack_group_config.default_stack_tags } }
 
 sceptre_user_data:
   environment: !file src/tower/resources/environment.yaml

--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -34,7 +34,8 @@ parameters:
     - khai.do@sagebase.org
   TowerConfigFileName: "tower.yaml"
 
-stack_tags: { { stack_group_config.default_stack_tags } }
+stack_tags: 
+  {{stack_group_config.default_stack_tags}}
 
 sceptre_user_data:
   environment: !file src/tower/resources/environment.yaml

--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -26,7 +26,7 @@ parameters:
   FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
   BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
   MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
-  RedisContainerImage: 'cr.seqera.io/public/redis:5.0.8'
+  # RedisContainerImage: 'cr.seqera.io/public/redis:5.0.8'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerUserWorkspace: 'false'

--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -26,6 +26,7 @@ parameters:
   FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
   BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
   MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
+  RedisContainerImage: 'cr.seqera.io/public/redis:5.0.8'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerUserWorkspace: 'false'

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -26,7 +26,6 @@ parameters:
   FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
   BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
   MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
-  # RedisContainerImage: 'cr.seqera.io/public/redis:5.0.8'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerUserWorkspace: 'false'

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -7,10 +7,10 @@ dependencies:
   - infra-prod/nextflow-elasticache-cluster.yaml
 
 parameters:
-  TowerSmtpHost: "email-smtp.us-east-1.amazonaws.com"
-  TowerSmtpPort: "587"
-  TowerSmtpUser: !ssm "smtp-username"
-  TowerSmtpPassword: !ssm "smtp-password"
+  TowerSmtpHost: 'email-smtp.us-east-1.amazonaws.com'
+  TowerSmtpPort: '587'
+  TowerSmtpUser: !ssm 'smtp-username'
+  TowerSmtpPassword: !ssm 'smtp-password'
   TowerContactEmail: nextflow-admins@sagebase.org
   TowerServerUrl: https://tower.sagebionetworks.org
   TowerRedisUrl: !stack_output_external nextflow-elasticache-cluster::RedisEndpoint
@@ -22,16 +22,16 @@ parameters:
   TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
-  CronContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
-  FrontendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}"
-  BackendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
-  MigrateDBContainerImage: "cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}"
+  CronContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
+  FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
+  BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
+  MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
-  EfsVolumeMountPath: "/efs"
-  TowerUserWorkspace: "false"
+  EfsVolumeMountPath: '/efs'
+  TowerUserWorkspace: 'false'
   TowerRootUsers:
     - thomas.yu@sagebase.org
-  TowerConfigFileName: "tower.yaml"
+  TowerConfigFileName: 'tower.yaml'
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -33,8 +33,9 @@ parameters:
     - thomas.yu@sagebase.org
   TowerConfigFileName: "tower.yaml"
 
-stack_tags: { { stack_group_config.default_stack_tags } }
-
+stack_tags: 
+  {{stack_group_config.default_stack_tags}}
+  
 sceptre_user_data:
   environment: !file src/tower/resources/environment.yaml
   EnableRedisDocker: false

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -26,7 +26,7 @@ parameters:
   FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
   BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
   MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
-  RedisContainerImage: 'cr.seqera.io/public/redis:5.0.8'
+  # RedisContainerImage: 'cr.seqera.io/public/redis:5.0.8'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerUserWorkspace: 'false'

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -26,6 +26,7 @@ parameters:
   FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
   BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
   MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
+  RedisContainerImage: 'cr.seqera.io/public/redis:5.0.8'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerUserWorkspace: 'false'

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -7,10 +7,10 @@ dependencies:
   - infra-prod/nextflow-elasticache-cluster.yaml
 
 parameters:
-  TowerSmtpHost: 'email-smtp.us-east-1.amazonaws.com'
-  TowerSmtpPort: '587'
-  TowerSmtpUser: !ssm 'smtp-username'
-  TowerSmtpPassword: !ssm 'smtp-password'
+  TowerSmtpHost: "email-smtp.us-east-1.amazonaws.com"
+  TowerSmtpPort: "587"
+  TowerSmtpUser: !ssm "smtp-username"
+  TowerSmtpPassword: !ssm "smtp-password"
   TowerContactEmail: nextflow-admins@sagebase.org
   TowerServerUrl: https://tower.sagebionetworks.org
   TowerRedisUrl: !stack_output_external nextflow-elasticache-cluster::RedisEndpoint
@@ -22,18 +22,18 @@ parameters:
   TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
-  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
-  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
-  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
+  CronContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
+  FrontendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}"
+  BackendContainerImage: "cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}"
+  MigrateDBContainerImage: "cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}"
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
-  EfsVolumeMountPath: '/efs'
-  TowerUserWorkspace: 'false'
+  EfsVolumeMountPath: "/efs"
+  TowerUserWorkspace: "false"
   TowerRootUsers:
     - thomas.yu@sagebase.org
-  TowerConfigFileName: 'tower.yaml'
+  TowerConfigFileName: "tower.yaml"
 
-stack_tags:
-  {{stack_group_config.default_stack_tags}}
+stack_tags: { { stack_group_config.default_stack_tags } }
 
 sceptre_user_data:
   environment: !file src/tower/resources/environment.yaml

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -33,9 +33,9 @@ parameters:
     - thomas.yu@sagebase.org
   TowerConfigFileName: "tower.yaml"
 
-stack_tags: 
+stack_tags:
   {{stack_group_config.default_stack_tags}}
-  
+
 sceptre_user_data:
   environment: !file src/tower/resources/environment.yaml
   EnableRedisDocker: false

--- a/config/projects-prod/robert-allaway-project.yaml
+++ b/config/projects-prod/robert-allaway-project.yaml
@@ -12,7 +12,7 @@ stack_tags:
   CostCenter: NO PROGRAM / 000000 # Valid values here: https://github.com/Sage-Bionetworks/aws-infra/tree/master/templates/tags
 
 parameters:
-  S3ReadOnlyAccessArns:
+  S3ReadWriteAccessArns:
     - "{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/jineta.banerjee@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/sasha.scott@sagebase.org"

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -83,6 +83,15 @@ Parameters:
     Type: String
     Description: Redis container docker image, e.g. 'redis:5.0.8'
 {%- endif %}
+  MigrateDBContainerName:
+    Type: String
+    Description: (Optional) Name of the migrate-db container
+    Default: migrate-db
+  MigrateDBContainerImage:
+    Type: String
+    Description: >
+      (Optional) migrate-db container docker image,
+      e.g. 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:v23.4.3'
   CronContainerName:
     Type: String
     Description: (Optional) Name of the cron container
@@ -180,6 +189,21 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
+        - image: !Ref RedisContainerImage
+          repositoryCredentials:
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
+        - image: !Ref MigrateDBContainerImage
+          repositoryCredentials:
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'      
+        - image: !Ref FrontendContainerImage
+          repositoryCredentials:
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'        
+        - image: !Ref BackendContainerImage
+          repositoryCredentials:
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
+        - image: !Ref CronContainerImage
+          repositoryCredentials:
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
       {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
         # The following container definition is a stop-gap solution for
         # https://sagebionetworks.jira.com/browse/WORKFLOWS-521
@@ -229,8 +253,8 @@ Resources:
               awslogs-group: !Ref TowerTaskLogGroup
               awslogs-stream-prefix: !Ref AwslogsStreamPrefix
       {%- endif %}
-        - Name: !Sub '${CronContainerName}-MigrateDb'
-          Image: !Ref CronContainerImage
+        - Name: !Sub '${MigrateDBContainerName}'
+          Image: !Ref MigrateDBContainerImage
           Memory: 2000
           Cpu: 0
           Essential: false
@@ -275,7 +299,7 @@ Resources:
             - ContainerName: !Ref RedisContainerName
               Condition: START
       {%- endif %}
-            - ContainerName: !Sub '${CronContainerName}-MigrateDb'
+            - ContainerName: !Sub '${MigrateDBContainerName}'
               Condition: SUCCESS
           WorkingDirectory: /work
           EntryPoint:

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -100,7 +100,7 @@ Parameters:
     Type: String
     Description: >
       (Optional) Cron container docker image,
-      e.g. '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.0'
+      e.g. 'cr.seqera.io/private/nf-tower-enterprise/backend:v21.06.0'
   FrontendContainerName:
     Type: String
     Description: (Optional) Name of the container that runs the tower ui
@@ -109,7 +109,7 @@ Parameters:
     Type: String
     Description: >
       Frontend container docker image,
-      e.g. '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v21.06.0'
+      e.g. 'cr.seqera.io/private/nf-tower-enterprise/frontend:v21.06.0'
   FrontendContainerPort:
     Type: Number
     Description: (Optional) Port to open in frontend container
@@ -126,7 +126,7 @@ Parameters:
     Type: String
     Description: >
       Backend container docker image,
-      e.g. '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.0'
+      e.g. 'cr.seqera.io/private/nf-tower-enterprise/backend:v21.06.0'
   BackendContainerPort:
     Type: Number
     Description: (Optional) Port to open in backend container
@@ -194,10 +194,10 @@ Resources:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
         - image: !Ref MigrateDBContainerImage
           repositoryCredentials:
-            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'      
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
         - image: !Ref FrontendContainerImage
           repositoryCredentials:
-            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'        
+            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
         - image: !Ref BackendContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -189,11 +189,6 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
-        {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
-        - image: !Ref RedisContainerImage
-          repositoryCredentials:
-            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        {%- endif %}
         - image: !Ref MigrateDBContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -253,7 +253,7 @@ Resources:
               awslogs-group: !Ref TowerTaskLogGroup
               awslogs-stream-prefix: !Ref AwslogsStreamPrefix
       {%- endif %}
-        - Name: !Sub '${MigrateDBContainerName}'
+        - Name: !Ref MigrateDBContainerName
           Image: !Ref MigrateDBContainerImage
           Memory: 2000
           Cpu: 0
@@ -299,7 +299,7 @@ Resources:
             - ContainerName: !Ref RedisContainerName
               Condition: START
       {%- endif %}
-            - ContainerName: !Sub '${MigrateDBContainerName}'
+            - ContainerName: !Ref MigrateDBContainerName
               Condition: SUCCESS
           WorkingDirectory: /work
           EntryPoint:

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -191,20 +191,20 @@ Resources:
       ContainerDefinitions:
         - Name: !Ref MigrateDBContainerName
           Image: !Ref MigrateDBContainerImage
-          repositoryCredentials:
-            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
+          RepositoryCredentials:
+            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
         - Name: !Ref FrontendContainerName
           Image: !Ref FrontendContainerImage
-          repositoryCredentials:
-            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
+          RepositoryCredentials:
+            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
         - Name: !Ref BackendContainerName
           Image: !Ref BackendContainerImage
-          repositoryCredentials:
-            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
+          RepositoryCredentials:
+            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
         - Name: !Ref CronContainerName
           Image: !Ref CronContainerImage
-          repositoryCredentials:
-            credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
+          RepositoryCredentials:
+            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
       {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
         # The following container definition is a stop-gap solution for
         # https://sagebionetworks.jira.com/browse/WORKFLOWS-521

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -189,18 +189,6 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
-        - Name: !Ref MigrateDBContainerName
-          Image: !Ref MigrateDBContainerImage
-          RepositoryCredentials:
-            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        - Name: !Ref FrontendContainerName
-          Image: !Ref FrontendContainerImage
-          RepositoryCredentials:
-            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        - Name: !Ref BackendContainerName
-          Image: !Ref BackendContainerImage
-          RepositoryCredentials:
-            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
       {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
         # The following container definition is a stop-gap solution for
         # https://sagebionetworks.jira.com/browse/WORKFLOWS-521
@@ -252,6 +240,8 @@ Resources:
       {%- endif %}
         - Name: !Ref MigrateDBContainerName
           Image: !Ref MigrateDBContainerImage
+          RepositoryCredentials:
+            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
           Memory: 2000
           Cpu: 0
           Essential: false
@@ -285,6 +275,8 @@ Resources:
               awslogs-stream-prefix: !Ref AwslogsStreamPrefix
         - Name: !Ref CronContainerName
           Image: !Ref CronContainerImage
+          RepositoryCredentials:
+            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
           Memory: 2000
           Cpu: 0
       {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
@@ -326,6 +318,8 @@ Resources:
               awslogs-stream-prefix: !Ref AwslogsStreamPrefix
         - Name: !Ref FrontendContainerName
           Image: !Ref FrontendContainerImage
+          RepositoryCredentials:
+            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
           Memory: 2000
           Cpu: 0
           Essential: false
@@ -348,6 +342,8 @@ Resources:
           Memory: 2000
           Cpu: 0
           Image: !Ref BackendContainerImage
+          RepositoryCredentials:
+            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
           PortMappings:
             - ContainerPort: !Ref BackendContainerPort
               HostPort: !Ref BackendHostPort

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -183,7 +183,7 @@ Resources:
   TowerTask:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      ExecutionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
+      executionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
       NetworkMode: bridge
       Volumes:
         - Name: !Ref EfsVolumeName

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -183,6 +183,7 @@ Resources:
   TowerTask:
     Type: AWS::ECS::TaskDefinition
     Properties:
+      ExecutionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
       NetworkMode: bridge
       Volumes:
         - Name: !Ref EfsVolumeName

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -183,7 +183,7 @@ Resources:
   TowerTask:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      executionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
+      ExecutionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
       NetworkMode: bridge
       Volumes:
         - Name: !Ref EfsVolumeName

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -201,10 +201,6 @@ Resources:
           Image: !Ref BackendContainerImage
           RepositoryCredentials:
             CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        - Name: !Ref CronContainerName
-          Image: !Ref CronContainerImage
-          RepositoryCredentials:
-            CredentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
       {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
         # The following container definition is a stop-gap solution for
         # https://sagebionetworks.jira.com/browse/WORKFLOWS-521

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -189,16 +189,20 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
-        - image: !Ref MigrateDBContainerImage
+        - Name: !Ref MigrateDBContainerName
+          Image: !Ref MigrateDBContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        - image: !Ref FrontendContainerImage
+        - Name: !Ref FrontendContainerName
+          Image: !Ref FrontendContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        - image: !Ref BackendContainerImage
+        - Name: !Ref BackendContainerName
+          Image: !Ref BackendContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
-        - image: !Ref CronContainerImage
+        - Name: !Ref CronContainerName
+          Image: !Ref CronContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
       {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -180,6 +180,21 @@ Resources:
       LogGroupName: '/aws/ecs/task/nf-tower'
       RetentionInDays: 30
 
+  EcsTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: EcsTaskExecutionRole
+      AssumeRolePolicyDocument:
+        Version:  '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        - arn:aws:iam::aws:policy/SecretsManagerReadWrite
+
   TowerTask:
     Type: AWS::ECS::TaskDefinition
     Properties:

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -189,9 +189,11 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
+        {%- if sceptre_user_data.EnableRedisDocker is defined and sceptre_user_data.EnableRedisDocker %}
         - image: !Ref RedisContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'
+        {%- endif %}
         - image: !Ref MigrateDBContainerImage
           repositoryCredentials:
             credentialsParameter: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:TOWER_DEV_SEQERA_REGISTRY_SECRET'


### PR DESCRIPTION
This PR includes all of the changes necessary to upgrade our Tower deployment to the new Seqera Platform.

**Notes:**
- This takes our `tower_version` from `v23.1.3` to `23.4.3`.
- An IAM role `EcsTaskExecutionRole` is added to the configuration to conduct the tower-task step.
- Containers are now pulled from the `cr.seqera.io/private/nf-tower-enterprise` repository.
- `robert-allaway-project` is reactivated.