### PR TITLE
[IBCSPRT-274] Enable Trace Debugging

### DIFF
--- a/src/tower/resources/environment.yaml
+++ b/src/tower/resources/environment.yaml
@@ -28,3 +28,4 @@ TOWER_ROOT_USERS: "!If [ HasTowerRootUsers, !Join [',', !Ref TowerRootUsers], !R
 TOWER_USER_WORKSPACE_ENABLED: "!Ref 'TowerUserWorkspace'"
 TOWER_CONFIG_FILE: "!Sub '${EfsVolumeMountPath}/${TowerConfigFileName}'"
 TOWER_ALLOW_INSTANCE_CREDENTIALS: "true"
+TOWER_LOG_LEVEL: "TRACE"


### PR DESCRIPTION
Recently when our new production deployment went live, one compute environment [ended up stuck](https://sagebionetworks.slack.com/archives/C048RL0RY74/p1720456913332599?thread_ts=1719943118.400519&cid=C048RL0RY74) in the `CREATING` state. I created a Seqera ticket, and they advised me to add this environment variable and deploy the infra again.