### PR TITLE
[IBCDPE-1006] Upgrades to v24.1.1

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v23.4.3
+tower_version: v24.1.1
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
This PR upgrades our tower_version to v24.1.1. This will introduce a change which prevents compute environments from failing to be created.