### PR TITLE
Revert "[IBCDPE-1006] Upgrades to v24.1.1"

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v24.1.1
+tower_version: v23.4.3
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
Reverts Sage-Bionetworks-Workflows/nextflow-infra#340. 

The deployment failed and I have created a ticket with Seqera to help debug. Reverting these changes in the meantime because the dev deployment is down currently.