### PR TITLE
Remove james from iatlas-project.yaml

### DIFF
--- a/config/projects-prod/iatlas-project.yaml
+++ b/config/projects-prod/iatlas-project.yaml
@@ -13,7 +13,6 @@ parameters:
     - "{{stack_group_config.tower_viewer_arn_prefix}}/brad.macdonald@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/adam.taylor@sagebase.org"
-    - "{{stack_group_config.tower_viewer_arn_prefix}}/james.eddy@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/bryan.fauble@sagebase.org"
     # The following roles don't exist since the users are not Sage employees.
     # However, this will ensure that they are added to the Tower workspace

--- a/config/projects-prod/imcore-project.yaml
+++ b/config/projects-prod/imcore-project.yaml
@@ -8,7 +8,6 @@ dependencies:
 parameters:
   S3ReadOnlyAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
-    - '{{stack_group_config.tower_viewer_arn_prefix}}/james.eddy@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'


### PR DESCRIPTION
**Problem:**

1. Running into:

> projects-prod/iatlas-project iatlas-project AWS::CloudFormation::Stack UPDATE_ROLLBACK_IN_PROGRESS Cannot export output S3ReadWriteAccessArns with length 1090. Max length of 1024 exceeded.


**Solution:**

1. Remove James from the list as he no longer is at Sage