### PR TITLE
Disables `nf-test-project` Compute Environments

### DIFF
--- a/config/projects-prod/nf-test-project.yaml
+++ b/config/projects-prod/nf-test-project.yaml
@@ -12,7 +12,7 @@ stack_tags:
   CostCenter: NTAP NF Addendum 4 / 301100
 
 parameters:
-  S3ReadWriteAccessArns:
+  S3ReadOnlyAccessArns:
     # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org'


### PR DESCRIPTION
This updates nf-test-project.yaml to disable the compute environments for this project, freeing up space for other projects environments