### PR TITLE
[IT-3929] Upgrade MySql version

### DIFF
--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -63,9 +63,9 @@ Parameters:
 Mappings:
   ClusterSettings:
     mysql:
-      version: 5.7.mysql_aurora.2.07.1
+      version: 8.0.mysql_aurora.3.07.1
       engine: aurora-mysql
-      family: aurora-mysql5.7
+      family: aurora-mysql8.0
 
 Conditions:
   UseSnapshotTrue: !Not [!Equals [!Ref SnapshotName, '']]


### PR DESCRIPTION
MySql 5.7 is EOL therefore we need to upgrade to the new AWS supported version of MySql

This is going to do an `In-place upgrade`[1].  The idea is to upgrade it in dev environment -> test -> propogate to prod -> test.

[1] https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.MySQL57.EOL.html#Aurora-Performing-an-Upgrade