### PR TITLE
Deactivating mc2-histoqc-project.yaml

### DIFF
--- a/config/projects-prod/mc2-histoqc-project.yaml
+++ b/config/projects-prod/mc2-histoqc-project.yaml
@@ -6,7 +6,7 @@ dependencies:
   - common/nextflow-launch-iam-policy.yaml
 
 parameters:
-  S3ReadWriteAccessArns:
+  S3ReadOnlyAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/adam.taylor@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/chelsea.nayan@sagebase.org'


### PR DESCRIPTION
This PR deactivates `mc2-histoqc-project.yaml`

@BWMac please review 