### PR TITLE
[IT-3929] Update MySQL DB cluster

### DIFF
--- a/config/infra-dev/nextflow-aurora-mysql8.yaml
+++ b/config/infra-dev/nextflow-aurora-mysql8.yaml
@@ -1,0 +1,26 @@
+# MySql cluster version 3.0 with serverless v2
+template:
+  path: nextflow-aurora-mysql.yaml
+stack_name: nextflow-aurora-mysql8
+dependencies:
+  - infra-dev/workflows-kms-key.yaml
+  - infra-dev/nextflow-vpc.yaml
+  - infra-dev/nextflow-ecs-security-group.yaml
+
+parameters:
+  DBClusterIdentifier: tower8
+  DBName: tower8
+  DbClusterMapping: mysql8
+  KmsKeyAlias: alias/nextflow-aurora-bootstrap-lambda8
+  VpcID: !stack_output_external nextflow-vpc::VPCId
+  SubnetIDs:
+    - !stack_output_external nextflow-vpc::PrivateSubnet1
+    - !stack_output_external nextflow-vpc::PrivateSubnet2
+  EcsSecurityGroupId: !stack_output_external nextflow-ecs-security-group::SecurityGroupId
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
+  AccountAdminArns:
+    - {{stack_group_config.sso_admin_role.arn}}
+    - !stack_output_external sagebase-github-oidc-workflows-dev-nextflow-infra::ProviderRoleArn
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -79,12 +79,14 @@ Mappings:
       version: 5.7.mysql_aurora.2.07.1
       engine: aurora-mysql
       family: aurora-mysql5.7
-      enginemode: serverless
+      EngineMode: serverless
+      EnableHttpEndpoint: true
     mysql8:
       version: 8.0.mysql_aurora.3.04.0
       engine: aurora-mysql
       family: aurora-mysql8.0
-      enginemode: provisioned
+      EngineMode: provisioned
+      EnableHttpEndpoint: false
 
 Conditions:
   UseSnapshotTrue: !Not [!Equals [!Ref SnapshotName, '']]
@@ -240,7 +242,7 @@ Resources:
       - CloudWatchDBClusterSlowQueryLogGroup
     Properties:
       Engine: !FindInMap [ ClusterSettings, !Ref DbClusterMapping, engine ]
-      EngineMode: !FindInMap [ ClusterSettings, !Ref DbClusterMapping, enginemode ]
+      EngineMode: !FindInMap [ ClusterSettings, !Ref DbClusterMapping, EngineMode ]
       EngineVersion: !FindInMap [ ClusterSettings, !Ref DbClusterMapping, version ]
       DatabaseName: !Ref DBName
       DBClusterIdentifier: !Ref DBClusterIdentifier
@@ -256,7 +258,7 @@ Resources:
       StorageEncrypted:  !If [UseSnapshotTrue, !Ref 'AWS::NoValue', true]
       DBClusterParameterGroupName: !Ref AuroraClusterParameterGroup
       BackupRetentionPeriod: 14
-      EnableHttpEndpoint: true
+      EnableHttpEndpoint: !FindInMap [ ClusterSettings, !Ref DbClusterMapping, EnableHttpEndpoint ]
       DBSubnetGroupName: !Ref DBSubnetGroup
       VpcSecurityGroupIds:
         - !Ref ClusterSecurityGroup

--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -60,12 +60,31 @@ Parameters:
     Type: List<String>
     Description: List of admin IAM user and role ARNs (strings)
 
+  DbClusterMapping:
+    Type: String
+    Description: List of admin IAM user and role ARNs (strings)
+    AllowedValues:
+      - mysql5
+      - mysql8
+    Default: mysql5
+
+  KmsKeyAlias:
+    Type: String
+    Description: Alias name of KMS key to use for encryption
+    Default: alias/nextflow-aurora-bootstrap-lambda
+
 Mappings:
   ClusterSettings:
-    mysql:
+    mysql5:
       version: 5.7.mysql_aurora.2.07.1
       engine: aurora-mysql
       family: aurora-mysql5.7
+      enginemode: serverless
+    mysql8:
+      version: 8.0.mysql_aurora.3.04.0
+      engine: aurora-mysql
+      family: aurora-mysql8.0
+      enginemode: provisioned
 
 Conditions:
   UseSnapshotTrue: !Not [!Equals [!Ref SnapshotName, '']]
@@ -80,7 +99,7 @@ Resources:
       TemplateURL: !Sub ${TemplateRootUrl}/aws-infra/v0.6.83/KMS/kms-key.yaml
       TimeoutInMinutes: 5
       Parameters:
-        AliasName: 'alias/nextflow-aurora-bootstrap-lambda'
+        AliasName: !Ref KmsKeyAlias
         AdminPrincipalArns: !Join
           - ','
           - - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
@@ -200,7 +219,7 @@ Resources:
     Type: AWS::RDS::DBClusterParameterGroup
     Properties:
       Description: Custom Database Parameters
-      Family: !FindInMap [ ClusterSettings, mysql, family ]
+      Family: !FindInMap [ ClusterSettings, !Ref DbClusterMapping, family ]
       Parameters:
         log_output: FILE
         general_log: "1"
@@ -220,9 +239,9 @@ Resources:
       - CloudWatchDBClusterGeneralLogGroup
       - CloudWatchDBClusterSlowQueryLogGroup
     Properties:
-      Engine: !FindInMap [ ClusterSettings, mysql, engine ]
-      EngineMode: serverless
-      EngineVersion: !FindInMap [ ClusterSettings, mysql, version ]
+      Engine: !FindInMap [ ClusterSettings, !Ref DbClusterMapping, engine ]
+      EngineMode: !FindInMap [ ClusterSettings, !Ref DbClusterMapping, enginemode ]
+      EngineVersion: !FindInMap [ ClusterSettings, !Ref DbClusterMapping, version ]
       DatabaseName: !Ref DBName
       DBClusterIdentifier: !Ref DBClusterIdentifier
       MasterUsername: !If
@@ -291,7 +310,7 @@ Resources:
       Description: Bootstrap newly Created Aurora Database
       Handler: index.lambda_handler
       Role: !GetAtt BootstrapLambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.10
       Environment:
         Variables:
           CLUSTER_ARN: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${AuroraCluster}'

--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -277,7 +277,7 @@ Resources:
       Engine: aurora-mysql
       DBClusterIdentifier:
         Ref: AuroraCluster
-      DBInstanceClass: db.r8g.large   # Data API isn't supported on "t" DB instance classes
+      DBInstanceClass: db.r6g.large   # Data API isn't supported on "t" DB instance classes
 
   # this custom resource exists to trigger the bootstrap lambda on creation
   BootstrapLambdaTrigger:

--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -82,11 +82,11 @@ Mappings:
       EngineMode: serverless
       EnableHttpEndpoint: true
     mysql8:
-      version: 8.0.mysql_aurora.3.04.0
+      version: 8.0.mysql_aurora.3.08.1
       engine: aurora-mysql
       family: aurora-mysql8.0
       EngineMode: provisioned
-      EnableHttpEndpoint: false
+      EnableHttpEndpoint: true
 
 Conditions:
   UseSnapshotTrue: !Not [!Equals [!Ref SnapshotName, '']]
@@ -120,7 +120,7 @@ Resources:
       GenerateSecretString:
         SecretStringTemplate: '{"username": "admin"}'
         GenerateStringKey: password
-        ExcludeCharacters: '"@/\$`&'
+        ExcludePunctuation: true
         PasswordLength: 16
       KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
 
@@ -133,7 +133,7 @@ Resources:
       GenerateSecretString:
         SecretStringTemplate: !Sub '{"username": "${DBUserName}"}'
         GenerateStringKey: password
-        ExcludeCharacters: '"@/\$`&'
+        ExcludePunctuation: true
         PasswordLength: 16
       KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
 
@@ -263,10 +263,28 @@ Resources:
       VpcSecurityGroupIds:
         - !Ref ClusterSecurityGroup
 
+  DBParameterGroup:
+    Type: 'AWS::RDS::DBParameterGroup'
+    Properties:
+      Description: Aurora Database Parameter Group
+      Family: aurora-mysql8.0
+
+  DBInstance1:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBParameterGroupName:
+        Ref: DBParameterGroup
+      Engine: aurora-mysql
+      DBClusterIdentifier:
+        Ref: AuroraCluster
+      DBInstanceClass: db.r8g.large   # Data API isn't supported on "t" DB instance classes
+
   # this custom resource exists to trigger the bootstrap lambda on creation
   BootstrapLambdaTrigger:
     Condition: UseSnapshotFalse
     Type: Custom::BootstrapLambdaTrigger
+    DependsOn:
+      - DBInstance1
     Properties:
       ServiceToken: !GetAtt BootstrapLambdaFunction.Arn
 
@@ -331,11 +349,11 @@ Resources:
           log.setLevel(logging.DEBUG)
 
           def submit_sql(sql):
+            log.debug(f'Submitting SQL: {sql}')
             return boto3.client('rds-data').execute_statement(
               secretArn=environ['MASTER_SECRET_ARN'],
               database=environ['DB_NAME'],
               resourceArn=environ['CLUSTER_ARN'],
-              schema='mysql',
               sql=sql
             )
 
@@ -347,9 +365,11 @@ Resources:
               secret = json.loads(secret_response['SecretString'])
               username = secret['username']
               password = secret['password']
+              log.debug(f'submit to database: {environ["DB_NAME"]}')
+              log.debug(f'using resourceArn: {environ["CLUSTER_ARN"]}')
               alter_db_response = submit_sql(f"ALTER DATABASE {db_name} CHARACTER SET utf8 COLLATE utf8_bin;")
               log.debug(f"Alter DB response: {alter_db_response}")
-              create_user_response = submit_sql(f"CREATE USER '{username}' IDENTIFIED BY '{password}';")
+              create_user_response = submit_sql(f"CREATE USER IF NOT EXISTS '{username}' IDENTIFIED BY '{password}';")
               log.debug(f"Create user response: {create_user_response}")
               grant_response = submit_sql(f"GRANT ALL PRIVILEGES ON {db_name}.* TO {username}@'%' ;")
               log.debug(f"Grant privileges response: {grant_response}")
@@ -369,6 +389,7 @@ Resources:
 
 
           def lambda_handler(event, context):
+            log.debug('Received event: ' + json.dumps(event, sort_keys=False))
             status = cfnresponse.SUCCESS
             message = 'no-op'
             error = None


### PR DESCRIPTION
Attempts to do in-place MySql DB upgrade from v5.7 to v8.0 does not work therefore this is going to do a blue/green upgrade. We will create a new parallel MySql v8.0 DB cluster, migrate the existing data from the old DB to the new DB then switch the Seqera app servers to use the new DB.