### PR TITLE
[DPE-1263] Activate Olfactory workspace & deactivate PEGS/mc2-mcmicro 

### DIFF
--- a/config/projects-prod/mc2-mcmicro-project.yaml
+++ b/config/projects-prod/mc2-mcmicro-project.yaml
@@ -6,7 +6,7 @@ dependencies:
   - common/nextflow-launch-iam-policy.yaml
 
 parameters:
-  S3ReadWriteAccessArns:
+  S3ReadOnlyAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/adam.taylor@sagebase.org'
     - arn:aws:iam::292075781285:user/cy101
     - arn:aws:iam::292075781285:user/jmuhlich

--- a/config/projects-prod/olfactory-challenge-project.yaml
+++ b/config/projects-prod/olfactory-challenge-project.yaml
@@ -1,0 +1,30 @@
+stack_name: olfactory-challenge-project
+
+stack_tags:
+  Department: DNT
+  Project: Olfactory Challenge
+  OwnerEmail: nextflow-admins@sagebase.org
+  CostCenter: Monell Predicting Human Olfactory Perception / 124500 # Valid values here: https://mips-api.finops.sageit.org/tags
+
+parameters:
+  S3ReadWriteAccessArns:
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jenny.medina@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/brad.macdonald@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/verena.chung@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/gaia.andreoletti@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/maria.diaz@sagebase.org'
+
+  AccountAdminArns:
+    - "{{stack_group_config.sso_admin_role.arn}}"
+    - !stack_output_external sagebase-github-oidc-workflows-prod-nextflow-infra::ProviderRoleArn
+  TemplateRootUrl: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com"
+  TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
+  TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+
+template:
+  path: tower-project.j2
+
+dependencies:
+  - common/nextflow-forge-iam-policy.yaml
+  - common/nextflow-launch-iam-policy.yaml

--- a/config/projects-prod/pegs-challenge-project.yaml
+++ b/config/projects-prod/pegs-challenge-project.yaml
@@ -7,7 +7,7 @@ stack_tags:
   CostCenter: PEGS Gene Environment / 124700 # Valid values here: https://mips-api.finops.sageit.org/tags
 
 parameters:
-  S3ReadWriteAccessArns:
+  S3ReadOnlyAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/rchai@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/jenny.medina@sagebase.org'


### PR DESCRIPTION
# Problem:

We need to deactivate some unused workspaces to make room for new ones, like a new workspace for the upcoming olfactory predictions challenge.

# Solution:

- [x] Introduce config file for new olfactory challenge workspace
- [x] Decomission PEGS workspace
- [x] Decomission MC2 mcmicro workspace

I used [this documentation](https://sagebionetworks.jira.com/wiki/spaces/WF/pages/2704539735/Nextflow+Tower+Administration#Deactivating-and-Reactivating-Workspaces) for deactivating and activating workspaces.

I confirmed with Adam that the MC2 mcmicro workspace can be decomissioned.

# Testing:
N/A