### PR TITLE
[IT-3970] Configure CORS for Data Explorer

### DIFF
--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -351,9 +351,9 @@ Resources:
             - Id: SynapseCORSRule
               AllowedHeaders: ["*"]
               AllowedOrigins: ["*"]
-              AllowedMethods: [GET, POST, PUT, HEAD, DELETE]
+              AllowedMethods: ["GET", "POST", "PUT", "HEAD", "DELETE"]
               MaxAge: 3000
-              ExposeHeaders: ETag
+              ExposeHeaders: ["ETag"]
             - Id: NullCorsRule
               AllowedHeaders: [""]
               AllowedOrigins: [""]

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -351,8 +351,9 @@ Resources:
             - Id: SynapseCORSRule
               AllowedHeaders: ["*"]
               AllowedOrigins: ["*"]
-              AllowedMethods: [GET, POST, PUT, HEAD]
+              AllowedMethods: [GET, POST, PUT, HEAD, DELETE]
               MaxAge: 3000
+              ExposeHeaders: ETag
             - Id: NullCorsRule
               AllowedHeaders: [""]
               AllowedOrigins: [""]


### PR DESCRIPTION
Add CORS configuration to needed to enable Seqera Data Explorer.

__Note__:All existing tower projects are configured with `SynapseIndexingEnabled`