### PR TITLE
deactivate old Tower accounts on strides

### DIFF
--- a/config/projects-ampad/example-ampad-project.yaml
+++ b/config/projects-ampad/example-ampad-project.yaml
@@ -6,7 +6,7 @@ dependencies:
   - common/nextflow-launch-iam-policy.yaml
 
 parameters:
-  S3ReadWriteAccessArns:
+  S3ReadOnlyAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
   S3ReadOnlyAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/brad.macdonald@sagebase.org'

--- a/config/projects-ampad/example-ampad-project.yaml
+++ b/config/projects-ampad/example-ampad-project.yaml
@@ -8,7 +8,6 @@ dependencies:
 parameters:
   S3ReadOnlyAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
-  S3ReadOnlyAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/brad.macdonald@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:

--- a/config/projects-ampad/jared-hendrickson-project.yaml
+++ b/config/projects-ampad/jared-hendrickson-project.yaml
@@ -6,7 +6,7 @@ dependencies:
   - common/nextflow-launch-iam-policy.yaml
 
 parameters:
-  S3ReadWriteAccessArns:
+  S3ReadOnlyAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/william.poehlman@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/jaclyn.beck@sagebase.org'

--- a/config/projects-ampad/wei-an-chen-project.yaml
+++ b/config/projects-ampad/wei-an-chen-project.yaml
@@ -6,7 +6,7 @@ dependencies:
   - common/nextflow-launch-iam-policy.yaml
 
 parameters:
-  S3ReadWriteAccessArns:
+  S3ReadOnlyAccessArns:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/william.poehlman@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/wei-an.chen@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'


### PR DESCRIPTION
As pointed out by @zaro0508 , there are a few lingering instances running from Tower accounts that are no longer active. To remove these instances and prevent them from re-launching, I would like to deactivate these three accounts, while maintaining access to the workspace and S3 buckets:

- example-ampad-project (test project, no longer needed)
- jared-hendrickson-project (no longer at Sage)
- wei-an-chen-project (no longer at Sage)