### PR TITLE
Revert "[IT-3970] Configure CORS for Data Explorer (#393)"

### DIFF
--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -351,9 +351,8 @@ Resources:
             - Id: SynapseCORSRule
               AllowedHeaders: ["*"]
               AllowedOrigins: ["*"]
-              AllowedMethods: ["GET", "POST", "PUT", "HEAD", "DELETE"]
+              AllowedMethods: [GET, POST, PUT, HEAD]
               MaxAge: 3000
-              ExposeHeaders: ["ETag"]
             - Id: NullCorsRule
               AllowedHeaders: [""]
               AllowedOrigins: [""]


### PR DESCRIPTION
This reverts commit 381f67225ccbafaff1f4896d65b1c5abc71aad12. This causes the following error:

AWS::S3::Bucket UPDATE_FAILED Properties validation failed for resource TowerBucket with message: [#/CorsConfiguration/CorsRules/0: extraneous key [ExposeHeaders] is not permitted]