### PR TITLE
Revert "[IT-2361] Custom Batch compute environment (#383)" 

### DIFF
--- a/templates/nextflow-ecs-cluster.yaml
+++ b/templates/nextflow-ecs-cluster.yaml
@@ -196,11 +196,6 @@ Outputs:
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsLaunchTemplate'
 
-  EcsLaunchTemplateLatestVersionNumber:
-    Value: !GetAtt EcsLaunchTemplate.LatestVersionNumber
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsLaunchTemplateLatestVersionNumber'
-
   EcsAutoScalingGroupName:
     Value: !Ref EcsAutoScalingGroup
     Export:

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -308,17 +308,6 @@ Resources:
               - "arn:aws:iam::325565585839:root"
               - !Ref AWS::NoValue
 
-  TowerLaunchStack:
-    Type: AWS::CloudFormation::Stack
-    Properties:
-      TemplateURL: !Sub ${TemplateRootUrl}/aws-infra/v0.9.5/NextflowTower/nextflow-launch.yaml
-      TimeoutInMinutes: 5
-      Parameters:
-        EcsSecurityGroupId:
-          'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-ecs-security-group-SecurityGroupId
-        SubnetIds:
-          'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-vpc-PrivateSubnet
-
   TowerBucket:
     Type: AWS::S3::Bucket
     Properties:


### PR DESCRIPTION
This reverts "[IT-2361] Custom Batch compute environment (#383)" and
 "[IT-2361] Add output for nextflow-ecs-cluster (#384)"

This change caused the following error:
Cannot update export us-east-1-nextflow-ecs-cluster-EcsLaunchTemplateLatestVersionNumber
as it is in use by example-dev-project-TowerLaunchStack-1SUJRFJRRXI9R,
mc2-mcmicro-dev-project-TowerLaunchStack-1VCENXR0MUDE3 and
orca-dev-project-TowerLaunchStack-O4QBS7AKXZ6 (and 2 more).

The reverted changes added nexflowl-launch.yaml[1] to every project template introducing
a circular dependency to  "us-east-1-nextflow-ecs-cluster-EcsLaunchTemplateLatestVersionNumber".
That dependency essentially locks the version number preventing cloudformation
from updating the version number in the cloudformation exports.  

[1] https://github.com/Sage-Bionetworks/aws-infra/blob/master/templates/NextflowTower/nextflow-launch.yaml 


[IT-2361]: https://sagebionetworks.jira.com/browse/IT-2361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IT-2361]: https://sagebionetworks.jira.com/browse/IT-2361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ