### PR TITLE
update read access to strides-ampad-project

### DIFF
--- a/config/projects-ampad/strides-ampad-project.yaml
+++ b/config/projects-ampad/strides-ampad-project.yaml
@@ -10,8 +10,7 @@ parameters:
     - "{{stack_group_config.tower_viewer_arn_prefix}}/william.poehlman@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org"
   S3ReadOnlyAccessArns:
-    - arn:aws:iam::751556145034:role/jared-hendrickson-project-TowerForgeBatchHeadJobRo-1XYQQ76D6E75Z
-    - arn:aws:iam::751556145034:role/jared-hendrickson-project-TowerForgeBatchWorkJobRo-1V2DBC9NYIPOB
+    - "{{stack_group_config.tower_viewer_arn_prefix}}/beatriz.saldana@sagebase.org"
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - "{{stack_group_config.sso_admin_role.arn}}"


### PR DESCRIPTION
This PR updates the configuration of the strides-ampad-project workspace to do the following:

- Remove Jared Hendrickson (no longer works at Sage)
- Add read access to Beatriz, who will benefit from being able to read this workspace for troubleshooting/debugging purposes based on past runs. 