### PR TITLE
[IT-3929] New database version

### DIFF
--- a/config/infra-dev/nextflow-aurora-mysql-migration.yaml
+++ b/config/infra-dev/nextflow-aurora-mysql-migration.yaml
@@ -8,7 +8,7 @@ dependencies:
 
 parameters:
   DBClusterIdentifier: tower8
-  DBName: tower8
+  DBName: tower
   SnapshotName: "arn:aws:rds:us-east-1:035458030717:cluster-snapshot:seqera-tower-migrated-v5-7-to-v8-0"
   VpcCidr: !stack_output_external nextflow-vpc::VpcCidr
   VpcID: !stack_output_external nextflow-vpc::VPCId

--- a/config/infra-dev/nextflow-aurora-mysql-migration.yaml
+++ b/config/infra-dev/nextflow-aurora-mysql-migration.yaml
@@ -1,0 +1,24 @@
+template:
+  path: nextflow-aurora-mysql-migration.yaml
+stack_name: nextflow-aurora-mysql-migration
+dependencies:
+  - infra-dev/workflows-kms-key.yaml
+  - infra-dev/nextflow-vpc.yaml
+  - infra-dev/nextflow-ecs-security-group.yaml
+
+parameters:
+  DBClusterIdentifier: tower8
+  DBName: tower8
+  SnapshotName: "arn:aws:rds:us-east-1:035458030717:cluster-snapshot:seqera-tower-migrated-v5-7-to-v8-0"
+  VpcCidr: !stack_output_external nextflow-vpc::VpcCidr
+  VpcID: !stack_output_external nextflow-vpc::VPCId
+  SubnetIDs:
+    - !stack_output_external nextflow-vpc::PrivateSubnet1
+    - !stack_output_external nextflow-vpc::PrivateSubnet2
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
+  AccountAdminArns:
+    - {{stack_group_config.sso_admin_role.arn}}
+    - !stack_output_external sagebase-github-oidc-workflows-dev-nextflow-infra::ProviderRoleArn
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/templates/nextflow-aurora-mysql-migration.yaml
+++ b/templates/nextflow-aurora-mysql-migration.yaml
@@ -1,0 +1,266 @@
+# This template is based off of the original nextflow-aurora-mysql.yaml template,
+# modified to create a new DB based off of a manually migrated tower db snapshot
+# this deployment uses a provisioned DB instead of a serverless db.
+AWSTemplateFormatVersion: 2010-09-09
+Description: DB for Migrating from MySQL v5.7 to v8.0 using a DB snapshot
+
+Parameters:
+
+  VpcID:
+    Description: ID of VPC
+    Type: AWS::EC2::VPC::Id
+
+  VpcCidr:
+    Type: String
+    Description: CIDR block of VPC
+    AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
+    ConstraintDescription: Must be a valid IP CIDR range of the form x.x.x.x/x
+
+  SubnetIDs:
+    Description: A list of subnets in the chosen VPC
+    Type: List<AWS::EC2::Subnet::Id>
+
+  DBClusterIdentifier:
+    Description: Unique identifier of databse cluster.
+    Type: String
+    MinLength: 1
+    MaxLength: 63
+    AllowedPattern: "^(?!.*--)[a-zA-Z]+[0-9a-zA-Z-]*[0-9a-zA-Z]$"
+    ConstraintDescription: >
+      1 to 63 alphanumeric characters or hyphens.
+      First character must be a letter.
+      Can't contain two consecutive hyphens.
+      Can't end with a hyphen.
+    Default: tower
+
+  DBName:
+    Description: Optional. Database Name within cluster.
+    Type: String
+    MinLength: 1
+    MaxLength: 64
+    AllowedPattern: "^[a-zA-Z]+[0-9,a-z,A-Z$_]*$"
+    ConstraintDescription: >
+      1 to 64 alphanumeric characters, dollar sign, or underscore.
+      First character must be a letter.
+    Default: tower
+
+  DBUserName:
+    Description: Optional. Username to be created for database.
+    Type: String
+    MinLength: 1
+    MaxLength: 32
+    Default: tower
+
+  SnapshotName:
+    Description: Optional. Snapshot ID to restore database. Leave this blank if you are not restoring from a snapshot.
+    Type: String
+    Default: ''
+
+  TemplateRootUrl:
+    Type: String
+    Description: URL of S3 bucket where templates are deployed
+    ConstraintDescription: Must be a valid S3 HTTP URL
+
+  AccountAdminArns:
+    Type: List<String>
+    Description: List of admin IAM user and role ARNs (strings)
+
+Mappings:
+  ClusterSettings:
+    mysql:
+      engine: aurora-mysql
+# enable for creation of mysql v5.7 provisioned from snapshot
+#      version: 5.7.mysql_aurora.2.11.4
+#      family: aurora-mysql5.7
+# enable for migration from v5.7 to 8.0
+      family: "aurora-mysql8.0"
+      version: "8.0.mysql_aurora.3.08.2"
+
+Conditions:
+  UseSnapshotTrue: !Not [!Equals [!Ref SnapshotName, '']]
+
+Resources:
+
+  AuroraKeyStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub ${TemplateRootUrl}/aws-infra/v0.6.83/KMS/kms-key.yaml
+      TimeoutInMinutes: 5
+      Parameters:
+        AliasName: 'alias/nextflow-aurora-mysql-migration'
+        AdminPrincipalArns: !Join
+          - ','
+          - - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            - !Join [",", !Ref AccountAdminArns]
+        UserPrincipalArns: !Join
+          - ','
+          - - !Join [",", !Ref AccountAdminArns]
+
+  AuroraMasterSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub '${AWS::StackName}-MasterSecret'
+      Description: !Sub 'Aurora MySQL Master User Secret for CloudFormation Stack ${AWS::StackName}'
+      GenerateSecretString:
+        SecretStringTemplate: '{"username": "admin"}'
+        GenerateStringKey: password
+        ExcludeCharacters: '"@/\$`&'
+        PasswordLength: 16
+      KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
+
+  AuroraNextflowTowerDatabaseUserSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub '${AWS::StackName}-NextflowTowerDatabaseUserSecret'
+      Description: !Sub 'Aurora MySQL ${DBUserName} User Secret for CloudFormation Stack ${AWS::StackName}'
+      GenerateSecretString:
+        SecretStringTemplate: !Sub '{"username": "${DBUserName}"}'
+        GenerateStringKey: password
+        ExcludeCharacters: '"@/\$`&'
+        PasswordLength: 16
+      KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
+
+  DBSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Aurora DB Subnet Group
+      SubnetIds: !Ref SubnetIDs
+
+  ClusterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref VpcID
+      GroupDescription: Aurora Cluster Security Group
+      SecurityGroupIngress:
+        - Description: Inbound rule to allow database access
+          CidrIp: !Ref VpcCidr
+          IpProtocol: -1
+          FromPort: -1
+          ToPort: -1
+
+  CloudWatchDBClusterAuditLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/rds/cluster/${DBClusterIdentifier}/audit'
+      RetentionInDays: 30
+
+  CloudWatchDBClusterErrorLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/rds/cluster/${DBClusterIdentifier}/error'
+      RetentionInDays: 30
+
+  CloudWatchDBClusterGeneralLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/rds/cluster/${DBClusterIdentifier}/general'
+      RetentionInDays: 30
+
+  CloudWatchDBClusterSlowQueryLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/rds/cluster/${DBClusterIdentifier}/slowquery'
+      RetentionInDays: 30
+
+  AuroraClusterParameterGroup:
+    Type: AWS::RDS::DBClusterParameterGroup
+    Properties:
+      Description: Custom Database Parameters
+      Family: !FindInMap [ ClusterSettings, mysql, family ]
+      Parameters:
+        log_output: FILE
+        general_log: "1"
+        server_audit_logging: "1"
+        log_queries_not_using_indexes: "1"
+        slow_query_log: "1"
+        long_query_time: "10"
+        server_audit_events: "CONNECT,QUERY,QUERY_DCL,QUERY_DDL,QUERY_DML,TABLE"
+
+  AuroraCluster:
+    Type: AWS::RDS::DBCluster
+    DeletionPolicy: Snapshot
+    UpdateReplacePolicy: Snapshot
+    DependsOn:
+      - CloudWatchDBClusterAuditLogGroup
+      - CloudWatchDBClusterErrorLogGroup
+      - CloudWatchDBClusterGeneralLogGroup
+      - CloudWatchDBClusterSlowQueryLogGroup
+    Properties:
+      Engine: !FindInMap [ ClusterSettings, mysql, engine ]
+      EngineMode: provisioned
+      EngineVersion: !FindInMap [ ClusterSettings, mysql, version ]
+      DatabaseName: !Ref DBName
+      DBClusterIdentifier: !Ref DBClusterIdentifier
+      SnapshotIdentifier: !If [UseSnapshotTrue, !Ref SnapshotName, !Ref 'AWS::NoValue']
+      StorageEncrypted:  !If [UseSnapshotTrue, !Ref 'AWS::NoValue', true]
+      DBClusterParameterGroupName: !Ref AuroraClusterParameterGroup
+      BackupRetentionPeriod: 14
+      EnableHttpEndpoint: false
+      DBSubnetGroupName: !Ref DBSubnetGroup
+      VpcSecurityGroupIds:
+        - !Ref ClusterSecurityGroup
+
+
+  AuroraDBFirstInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      CopyTagsToSnapshot: true
+      DBInstanceClass: db.r6g.large
+      DBClusterIdentifier: !Ref AuroraCluster
+      Engine: !FindInMap [ ClusterSettings, mysql, engine ]
+      EngineVersion: !FindInMap [ ClusterSettings, mysql, version ]
+      DBSubnetGroupName: !Ref DBSubnetGroup
+      PubliclyAccessible: false
+
+Outputs:
+
+  AuroraMasterSecretArn:
+    Value: !Ref AuroraMasterSecret
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-AuroraMasterSecretArn'
+
+  AuroraNextflowTowerDatabaseUserSecretArn:
+    Value: !Ref AuroraNextflowTowerDatabaseUserSecret
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-AuroraNextflowTowerDatabaseUserSecretArn'
+
+  AuroraClusterEndpointAddress:
+    Value: !GetAtt AuroraCluster.Endpoint.Address
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-DBClusterEndpointAddress'
+
+  AuroraClusterEndpointPort:
+    Value: !GetAtt AuroraCluster.Endpoint.Port
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-DBClusterEndpointPort'
+
+  AuroraClusterName:
+    Value: !Ref AuroraCluster
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-DBClusterName'
+
+  DBUrl:
+    Value: !Join
+      - ''
+      - - !Sub 'jdbc:mysql://${AuroraCluster.Endpoint.Address}:'
+        - !Sub '${AuroraCluster.Endpoint.Port}/${DBName}?permitMysqlScheme=true'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-DBUrl'
+
+
+  AuroraClusterSecurityGroupID:
+    Value: !Ref ClusterSecurityGroup
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-DBClusterSecurityGroupID'
+
+  ClusterVpcID:
+    Value: !Ref VpcID
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-DBClusterVpcID'
+
+  ClusterSubnets:
+    Value: !Join
+      - ','
+      - !Ref SubnetIDs
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-DBClusterSubnetsList'

--- a/templates/nextflow-aurora-mysql-migration.yaml
+++ b/templates/nextflow-aurora-mysql-migration.yaml
@@ -1,6 +1,8 @@
 # This template is based off of the original nextflow-aurora-mysql.yaml template,
 # modified to create a new DB based off of a manually migrated tower db snapshot
 # this deployment uses a provisioned DB instead of a serverless db.
+# A DB migration requires some manual steps, please check issue IT-3929 and
+# the below comments around AuroraMasterSecret resource.
 AWSTemplateFormatVersion: 2010-09-09
 Description: DB for Migrating from MySQL v5.7 to v8.0 using a DB snapshot
 
@@ -96,6 +98,11 @@ Resources:
           - ','
           - - !Join [",", !Ref AccountAdminArns]
 
+  #####-----  !Important if doing a DB migration ----######
+  # These secrets manager resources are required because there are other things that
+  # depend on these resource.  Cloudformation will create these resources with new secrets
+  # however the new secrets will not work on an existing database.  We need to manually update
+  # the values in this resource to match the existing secrets for the old database.
   AuroraMasterSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
@@ -119,6 +126,8 @@ Resources:
         ExcludeCharacters: '"@/\$`&'
         PasswordLength: 16
       KmsKeyId: !Sub ${AuroraKeyStack.Outputs.Key}
+
+  #####-----------------------------------------------------######
 
   DBSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup


### PR DESCRIPTION
Create a new aurora MySQL v8.0 database for seqera tower. The template for the DB is based off of the original nextflow-aurora-mysql.yaml except that this DB will be used to migrate existing data onto it.  In this scenario we are creating a DB from an existing DB Snapshot which already contains the bootstrapping and data.  This scenario does not require a lambda, it assumes an existing DB snapshot to already exist.  We created the DB snapshot manually using instructions in issue IT-3929