### PR TITLE
[IT-3929] switch to new database

### DIFF
--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -2,7 +2,7 @@ template:
   path: nextflow-ecs-task-definition.j2
 stack_name: nextflow-ecs-task-definition
 dependencies:
-  - infra-dev/nextflow-aurora-mysql.yaml
+  - infra-dev/nextflow-aurora-mysql-migration.yaml
   - infra-dev/nextflow-efs-file-system.yaml
   - infra-dev/nextflow-elasticache-cluster.yaml
 
@@ -17,9 +17,9 @@ parameters:
   TowerJwtSecret: !aws_secrets_manager nextflow-tower-secret/jwt::SecretString::secret
   TowerCryptoSecretkey: !aws_secrets_manager nextflow-tower-secret/crypto::SecretString::secret
   TowerLicense: !aws_secrets_manager nextflow/license::SecretString::license_key
-  TowerDbUrl: !stack_output_external nextflow-aurora-mysql::DBUrl
-  TowerDbUser: !aws_secrets_manager nextflow-aurora-mysql-NextflowTowerDatabaseUserSecret::SecretString::username
-  TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-NextflowTowerDatabaseUserSecret::SecretString::password
+  TowerDbUrl: !stack_output_external nextflow-aurora-mysql-migration::DBUrl
+  TowerDbUser: !aws_secrets_manager nextflow-aurora-mysql-migration-NextflowTowerDatabaseUserSecret::SecretString::username
+  TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-migration-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
   CronContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'


### PR DESCRIPTION
Switch nextflow from using the existing MySQL v5.7 to using the new MySQL v8.0 database for the dev environment.

depends on #414