### PR TITLE
Remove last added user to DEV environment

### DIFF
--- a/config/projects-dev/example-dev-project.yaml
+++ b/config/projects-dev/example-dev-project.yaml
@@ -13,7 +13,6 @@ parameters:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/bryan.fauble@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/dan.lu@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/jenny.medina@sagebase.org'
-    - '{{stack_group_config.tower_viewer_arn_prefix}}/lingling.peng@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'


### PR DESCRIPTION
Our license for nextflow dev environment only allows 20 users, adding more will result in error "Limit of 20 members reached". removing the last added user.