### PR TITLE
[IT-4467] Add Nvidia based GPU instances

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -52,6 +52,15 @@ NONGPU_EC2_INSTANCE_TYPES = (
     "m6i.8xlarge", "r5a.8xlarge", "r6a.8xlarge", "r6i.8xlarge"
 )
 
+GPU_EC2_INSTANCE_TYPES = (
+    # Amazon linux 2023 AMIs:
+    #   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+    # GPU instance types:
+    #   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html
+    "p3.2xlarge", "p3.8xlarge", "p3.16xlarge", "p3dn.24xlarge", "p4d.24xlarge",
+    "p5.48xlarge"
+)
+
 ECS_CONFIG = """
 ECS_CONTAINER_STOP_TIMEOUT=10m
 ECS_CONTAINER_START_TIMEOUT=10m
@@ -645,7 +654,7 @@ class TowerWorkspace:
         # of instances when provisioning spot instances.
         instance_types = list(NONGPU_EC2_INSTANCE_TYPES)
         # Leaving this out based on Sage-Bionetworks-Workflows/nextflow-infra#161
-        # instance_types.extend(GPU_EC2_INSTANCE_TYPES)
+        instance_types.extend(GPU_EC2_INSTANCE_TYPES)
 
         # This is modeled after a request made in the Tower web client
         data = {
@@ -685,7 +694,7 @@ class TowerWorkspace:
                         "ec2KeyPair": None,
                         "ecsConfig": ECS_CONFIG.strip(),
                         "efsCreate": False,
-                        "gpuEnabled": False,
+                        "gpuEnabled": True,
                         "imageId": None,
                         "instanceTypes": instance_types,
                         "maxCpus": 1000,

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -58,7 +58,7 @@ GPU_EC2_INSTANCE_TYPES = (
     # GPU instance types:
     #   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html
     "p4d.24xlarge", "p4de.24xlarge", "p5.48xlarge", "p5e.48xlarge",
-    "p5en.48xlarge", "p6-b200.48xlarge", "p6e- gb200.36xlarge"
+    "p5en.48xlarge", "p6-b200.48xlarge", "p6e-gb200.36xlarge"
 )
 
 ECS_CONFIG = """

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -57,8 +57,8 @@ GPU_EC2_INSTANCE_TYPES = (
     #   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
     # GPU instance types:
     #   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html
-    "p3.2xlarge", "p3.8xlarge", "p3.16xlarge", "p3dn.24xlarge", "p4d.24xlarge",
-    "p5.48xlarge"
+    "p4d.24xlarge", "p4de.24xlarge", "p5.48xlarge", "p5e.48xlarge",
+    "p5en.48xlarge", "p6-b200.48xlarge", "p6e- gb200.36xlarge"
 )
 
 ECS_CONFIG = """


### PR DESCRIPTION
According to the Seqera docs[1], to enable GPUs we need to add Nvidia GPUs and enable it in seqera compute environments.  Everything else required to use the GPUs is done with the Nextflow language[2] and nvidia container toolkit[3]

[1] https://docs.seqera.io/platform-cloud/compute-envs/overview#gpu-usage
[2] https://www.nextflow.io/docs/latest/process.html#accelerator
[3] https://github.com/NVIDIA/nvidia-container-toolkit