### PR TITLE
[IT-4467] Remove unsupported instances

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -57,8 +57,8 @@ GPU_EC2_INSTANCE_TYPES = (
     #   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
     # GPU instance types:
     #   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html
-    "p4d.24xlarge", "p4de.24xlarge", "p5.48xlarge", "p5e.48xlarge",
-    "p5en.48xlarge", "p6-b200.48xlarge", "p6e-gb200.36xlarge"
+    "p4d.24xlarge", "p4de.24xlarge", "p5.48xlarge", "p5en.48xlarge",
+    "p6-b200.48xlarge"
 )
 
 ECS_CONFIG = """


### PR DESCRIPTION
Seqera platform does not support p5en.48xlarge
and p6e-gb200.36xlarge GPU instances.