### PR TITLE
[IT-3970] Upgrade Seqera Platform version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v24.1.3
+tower_version: v25.2.0
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
Seqera data explorer is not working correctly due to a dabase schema mismatch.
Seqera support recommends upgrading Seqera to v25.2.0 to allow the app to
bootstrap the correct schema.

from support ticket #6590:
```
There appears to be a column (hidden) that your current version of
the Platform should not be referencing yet, as it's only introduced
in a later version. However, this column seems to be missing, which
is causing the issue with Data Explorer.
```