### PR TITLE
Upgrade Seqera platform version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v24.1.3
+tower_version: v25.1.1
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
This is a redo of commit f07390f1e which failed to deploy. This time try to upgrade to v25.1.1 instead of v25.2.0