### PR TITLE
[IT-3929] New database version for prod environment (#417)

### DIFF
--- a/config/infra-prod/nextflow-aurora-mysql-migration.yaml
+++ b/config/infra-prod/nextflow-aurora-mysql-migration.yaml
@@ -1,0 +1,24 @@
+template:
+  path: nextflow-aurora-mysql-migration.yaml
+stack_name: nextflow-aurora-mysql-migration
+dependencies:
+  - infra-dev/workflows-kms-key.yaml
+  - infra-dev/nextflow-vpc.yaml
+  - infra-dev/nextflow-ecs-security-group.yaml
+
+parameters:
+  DBClusterIdentifier: tower8
+  DBName: tower
+  SnapshotName: "arn:aws:rds:us-east-1:728882028485:cluster-snapshot:seqera-tower-migrated-v5-7-to-v8-0"
+  VpcCidr: !stack_output_external nextflow-vpc::VpcCidr
+  VpcID: !stack_output_external nextflow-vpc::VPCId
+  SubnetIDs:
+    - !stack_output_external nextflow-vpc::PrivateSubnet1
+    - !stack_output_external nextflow-vpc::PrivateSubnet2
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
+  AccountAdminArns:
+    - {{stack_group_config.sso_admin_role.arn}}
+    - !stack_output_external sagebase-github-oidc-workflows-prod-nextflow-infra::ProviderRoleArn
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}


### PR DESCRIPTION
This is similar to PR #414 except this one is for prod environment.

Create a new aurora MySQL v8.0 database for seqera tower. The template for the DB is based off of the original nextflow-aurora-mysql.yaml except that this DB will be used to migrate existing data onto it. In this scenario we are creating a DB from an existing DB Snapshot which already contains the bootstrapping and data. This scenario does not require a lambda, it assumes an existing DB snapshot to already exist. We created the DB snapshot manually using instructions in issue IT-3929