### PR TITLE
promote PR #439 to prod

### DIFF
--- a/config/infra-ampad/nextflow-vpc.yaml
+++ b/config/infra-ampad/nextflow-vpc.yaml
@@ -1,6 +1,5 @@
 template:
-  type: http
-  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.3.0/templates/VPC/vpc-20-private.yaml"
+  path: "vpc-20-private.yaml"
 stack_name: nextflow-vpc
 
 parameters:

--- a/config/infra-dev/nextflow-vpc.yaml
+++ b/config/infra-dev/nextflow-vpc.yaml
@@ -1,6 +1,5 @@
 template:
-  type: http
-  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.3.0/templates/VPC/vpc-20-private.yaml"
+  path: "vpc-20-private.yaml"
 stack_name: nextflow-vpc
 
 parameters:

--- a/config/infra-prod/nextflow-vpc.yaml
+++ b/config/infra-prod/nextflow-vpc.yaml
@@ -1,6 +1,5 @@
 template:
-  type: http
-  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.3.0/templates/VPC/vpc-20-private.yaml"
+  path: "vpc-20-private.yaml"
 stack_name: nextflow-vpc
 
 parameters:

--- a/templates/vpc-20-private.yaml
+++ b/templates/vpc-20-private.yaml
@@ -1,0 +1,364 @@
+# This template is originally from
+# https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.3.0/templates/VPC/vpc-20-private.yaml
+AWSTemplateFormatVersion: "2010-09-09"
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks: [W3011]
+Description: >
+  Creates a VPC of 4096 addresses, mostly in private subnets, and a public
+  subnet to accommodate a NAT gateway.
+Parameters:
+  VpcName:
+    Description: The VPC name (i.e. Synapse-Prod)
+    Type: String
+  VpcSubnetPrefix:
+    Description: The VPC subnet prefix (i.e. 10.255)
+    Type: String
+  PublicSubnetZones:
+    Description: Availability zones for public subnets
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+    ConstraintDescription: List of Availability Zones in a region, such as us-east-1a, us-east-1b, us-east-1c
+    Default: "us-east-1a, us-east-1b, us-east-1c"
+  PrivateSubnetZones:
+    Description: Availability zones for private subnets
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+    ConstraintDescription: List of Availability Zones in a region, such as us-east-1a, us-east-1b, us-east-1c
+    Default: "us-east-1a, us-east-1b, us-east-1c, us-east-1d"
+  VpnCidr:
+    Description: CIDR of the (sophos-utm) VPN
+    Type: String
+    Default: "10.1.0.0/16"
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+Mappings:
+  SubnetConfig:
+    VPC:
+      CIDR: "0.0/20"  # 10.255.0.1 - 10.255.15.254
+    Private:
+      CIDR: "0.0/22"  # 10.255.0.1 - 10.255.3.254
+    Private1:
+      CIDR: "4.0/22"  # 10.255.4.1 - 10.255.7.254
+    Private2:
+      CIDR: "8.0/22"  # 10.255.8.1 - 10.255.11.254
+    Private3:
+      CIDR: "12.0/23" # 10.255.12.1 - 10.255.13.254
+    Public:
+      CIDR: "14.0/24" # 10.255.14.1 - 10.255.14.254
+    Public1:
+      CIDR: "15.0/24" # 10.255.15.1 - 10.255.15.254
+Resources:
+  VPC:
+    UpdateReplacePolicy: Retain
+    Type: "AWS::EC2::VPC"
+    Properties:
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, VPC, CIDR]
+      Tags:
+        - Key: "Name"
+          Value: !Ref VpcName
+  PublicSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      MapPublicIpOnLaunch: true
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Public, CIDR]
+      AvailabilityZone: !Select
+        - 0
+        - !Ref PublicSubnetZones
+  PublicSubnet1:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      MapPublicIpOnLaunch: true
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Public1, CIDR]
+      AvailabilityZone: !Select
+        - 1
+        - !Ref PublicSubnetZones
+  PrivateSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Private, CIDR]
+      AvailabilityZone: !Select
+        - 0
+        - !Ref PrivateSubnetZones
+  PrivateSubnet1:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Private1, CIDR]
+      AvailabilityZone: !Select
+        - 1
+        - !Ref PrivateSubnetZones
+  PrivateSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Private2, CIDR]
+      AvailabilityZone: !Select
+        - 2
+        - !Ref PrivateSubnetZones
+  PrivateSubnet3:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Private3, CIDR]
+      AvailabilityZone: !Select
+        - 3
+        - !Ref PrivateSubnetZones
+  InternetGateway:
+    UpdateReplacePolicy: Retain
+    Type: "AWS::EC2::InternetGateway"
+  GatewayToInternet:
+    Type: "AWS::EC2::VPCGatewayAttachment"
+    Properties:
+      VpcId:
+        Ref: "VPC"
+      InternetGatewayId:
+        Ref: "InternetGateway"
+  PublicRouteTable:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId:
+        Ref: "VPC"
+  PublicRoute:
+    Type: "AWS::EC2::Route"
+    DependsOn: "GatewayToInternet"
+    Properties:
+      RouteTableId:
+        Ref: "PublicRouteTable"
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId:
+        Ref: "InternetGateway"
+  PublicSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PublicSubnet"
+      RouteTableId:
+        Ref: "PublicRouteTable"
+  PublicSubnetRouteTableAssociation1:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PublicSubnet1"
+      RouteTableId:
+        Ref: "PublicRouteTable"
+  PublicNetworkAcl:
+    Type: "AWS::EC2::NetworkAcl"
+    Properties:
+      VpcId:
+        Ref: "VPC"
+  InboundHTTPPublicNetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+      RuleNumber: 100
+      Protocol: -1
+      RuleAction: "allow"
+      Egress: false
+      CidrBlock: "0.0.0.0/0"
+      PortRange:
+        From: 0
+        To: 65535
+  OutboundPublicNetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+      RuleNumber: 100
+      Protocol: -1
+      RuleAction: "allow"
+      Egress: true
+      CidrBlock: "0.0.0.0/0"
+      PortRange:
+        From: 0
+        To: 65535
+  PublicSubnetNetworkAclAssociation:
+    Type: "AWS::EC2::SubnetNetworkAclAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PublicSubnet"
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+  PublicSubnetNetworkAclAssociation1:
+    Type: "AWS::EC2::SubnetNetworkAclAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PublicSubnet1"
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+  NATGateway:
+    UpdateReplacePolicy: Retain
+    Type: "AWS::EC2::NatGateway"
+    Properties:
+      AllocationId:
+        Fn::GetAtt:
+          - "ElasticIP"
+          - "AllocationId"
+      SubnetId:
+        Ref: "PublicSubnet"
+  ElasticIP:
+    Type: "AWS::EC2::EIP"
+    Properties:
+      Domain: "vpc"
+  PrivateRouteTable:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId:
+        Ref: "VPC"
+  PrivateRouteToInternet:
+    Type: "AWS::EC2::Route"
+    Properties:
+      RouteTableId:
+        Ref: "PrivateRouteTable"
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId:
+        Ref: "NATGateway"
+  PrivateSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PrivateSubnet"
+      RouteTableId:
+        Ref: "PrivateRouteTable"
+  PrivateSubnetRouteTableAssociation1:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PrivateSubnet1"
+      RouteTableId:
+        Ref: "PrivateRouteTable"
+  PrivateSubnetRouteTableAssociation2:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PrivateSubnet2"
+      RouteTableId:
+        Ref: "PrivateRouteTable"
+  PrivateSubnetRouteTableAssociation3:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PrivateSubnet3"
+      RouteTableId:
+        Ref: "PrivateRouteTable"
+  # Allow access to EC2 when connected to the Sage VPN
+  VpnSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Security Group for VPN
+      VpcId:
+        Ref: "VPC"
+      SecurityGroupIngress:
+        - CidrIp: !Ref VpnCidr
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+          Description: "Allow all VPN traffic"
+      # CF does not support removing all rules, workaround is to add a pointless rule
+      SecurityGroupEgress:
+        - CidrIp: "0.0.0.0/0"
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+Outputs:
+  VPCId:
+    Description: "VPCId of the newly created VPC"
+    Value:
+      Ref: "VPC"
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VPCId']]
+  VpcCidr:
+    Description: "VPC CIDR of the newly created VPC"
+    Value: !GetAtt
+      - VPC
+      - CidrBlock
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpcCidr']]
+  PublicSubnet:
+    Description: "SubnetId of the public subnet"
+    Value: !Ref PublicSubnet
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PublicSubnet']]
+  PublicSubnet1:
+    Description: "SubnetId of the public subnet 1"
+    Value: !Ref PublicSubnet1
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PublicSubnet1']]
+  PrivateSubnet:
+    Description: "SubnetId of the private subnet"
+    Value: !Ref PrivateSubnet
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet']]
+  PrivateSubnet1:
+    Description: "SubnetId of the private subnet 1"
+    Value: !Ref PrivateSubnet1
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet1']]
+  PrivateSubnet2:
+    Description: "SubnetId of the private subnet 2"
+    Value: !Ref PrivateSubnet2
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet2']]
+  PrivateSubnet3:
+    Description: "SubnetId of the private subnet 3"
+    Value: !Ref PrivateSubnet3
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet3']]
+  PrivateRouteTable:
+    Description: "Route table Id for private subnets"
+    Value: !Ref PrivateRouteTable
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateRouteTable']]
+  VpcDefaultSecurityGroup:
+    Description: "VPC DefaultSecurityGroup Id"
+    Value: { "Fn::GetAtt":["VPC", "DefaultSecurityGroup"] }
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpcDefaultSecurityGroup']]
+  VpnSecurityGroup:
+    Description: "VPN Security Group Id"
+    Value: !Ref VpnSecurityGroup
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnSecurityGroup']]
+  VpnCidr:
+    Description: "CIDR of the VPN used for the VpnSecurityGroup SecurityIngress"
+    Value: !Ref VpnCidr
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnCidr']]


### PR DESCRIPTION
Deployment thru the CI attempts to create new VPC resources and causing the following failure[1] even thought the cloudformation diff detection shows no changes.

```
infra-dev/nextflow-vpc NATGateway AWS::EC2::NatGateway UPDATE_FAILED Resource
handler returned message: "Error occurred during operation 'NatGateway
nat-099a46339af1c5fc9 is in state failed and hence failed to stabilize.
Detailed failure message: Network vpc-07290d198a10e8739 has no Internet
gateway attached'."
```

I am not able to reproduce locally, my attempt to update locally always returns no changes from cloudformation.

As a work around we explicitly tell clouformation
to not create new resource when updating the template.

[1] https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/actions/runs/17598318619/job/50007210182