### PR TITLE
[IT-2361] Update Seqera enterprise

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v25.1.1
+tower_version: v25.2.2
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
Update to Seqera enterprise v25.2[1]
This is the first enterprise version to support the AWS cloud compute environment[2] which would allow getting past the 50 job queue per account per region contstraint.

[1] https://docs.seqera.io/changelog/seqera-enterprise/25.2.2
[2] https://docs.seqera.io/platform-enterprise/compute-envs/aws-cloud