### PR TITLE
Enable Seqera private workspace

### DIFF
--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -28,7 +28,7 @@ parameters:
   MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
-  TowerUserWorkspace: 'false'
+  TowerUserWorkspace: 'true'
   TowerRootUsers:
     - thomas.yu@sagebase.org
     - khai.do@sagebase.org

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -28,7 +28,7 @@ parameters:
   MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
-  TowerUserWorkspace: 'false'
+  TowerUserWorkspace: 'true'
   TowerRootUsers:
     - thomas.yu@sagebase.org
     - khai.do@sagebase.org


### PR DESCRIPTION
Enable private workspace to allow user to setup private credentials to access private repos.

TOWER_USER_WORKSPACE_ENABLED [1]
```
Enable or disable user private workspaces (requires version 22.1.0 or later).
```

[1] https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview