### PR TITLE
[IT-2361] Update Seqera enterprise to latest v25.1.x version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v25.1.1
+tower_version: v25.1.5
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
updating to v25.2.x failed to deploy[1] so we try bringing seqera to the latest v25.1.x before making another attempt at going to a v25.2.x version.

[1] https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/actions/runs/18420522428