### PR TITLE
Revert "[IT-2361] Update Seqera enterprise version (#474)"

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v25.2
+tower_version: v25.1.5
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
This reverts commit a96160cccb985060a818f24ffb8481d6313e5da3.

Failed to deploy with error..
CannotPullImageManifestError: Error response from daemon: unknown: resource
not found: repo private/nf-tower-enterprise/backend, tag v25.2 not found