### PR TITLE
[IT-2361] Update Seqera enterprise version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v25.1.5
+tower_version: v25.2.3
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
This is a 2nd attempt at updating to v25.2.  The first attempt in #474 failed to deploy and was reverted in #476. Seqera support says the fix is to update to the latest v25.2 version.

Update to Seqera enterprise to v25.2.3[1]. This is an enterprise version that supports the AWS cloud compute environment[2] which would allow getting past the 50 job queue per account per region constraint.

[1] https://docs.seqera.io/changelog/seqera-enterprise/v25.2.3
[2] https://docs.seqera.io/platform-enterprise/compute-envs/aws-cloud