### PR TITLE
[IT-3888] Add a test user for py-orca

### DIFF
--- a/config/projects-dev/example-dev-project.yaml
+++ b/config/projects-dev/example-dev-project.yaml
@@ -14,6 +14,7 @@ parameters:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/dan.lu@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/jenny.medina@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/lingling.peng@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/nextflow-tester@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'


### PR DESCRIPTION
The py-orca runs tests by trigging an example-dev-project workflow. We need to add our service user to seqera tower so it will have access to the tower project.

Note: This user is not in AWS, it's only in seqera tower. We need to add it as an AWS ARN because the configure-tower-project.py script takes users from the S3ReadWriteAccessArns and automatically adds them to the seqera project.