### PR TITLE
Revert "[DPESPRT-321] Add new users to tower viewer ARNs"

### DIFF
--- a/config/projects-ampad/agora-project.yaml
+++ b/config/projects-ampad/agora-project.yaml
@@ -14,8 +14,6 @@ parameters:
     - "{{stack_group_config.tower_viewer_arn_prefix}}/jessica.britton@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/beatriz.saldana@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/lingling.peng@sagebase.org"
-    - "{{stack_group_config.tower_viewer_arn_prefix}}/hallie.swan@sagebase.org"
-    - "{{stack_group_config.tower_viewer_arn_prefix}}/lawrence.yi@sagebase.org"
   AccountAdminArns:
     - "{{stack_group_config.sso_admin_role.arn}}"
     - !stack_output_external github-oidc-nextflow-infra::ProviderRoleArn


### PR DESCRIPTION
Reverts Sage-Bionetworks-Workflows/nextflow-infra#475, because this action failed: https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/actions/runs/19278844665