### PR TITLE
[IT-3888] Add a test user for py-orca prod

### DIFF
--- a/config/projects-prod/example-project.yaml
+++ b/config/projects-prod/example-project.yaml
@@ -21,6 +21,7 @@ parameters:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/dan.lu@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/jenny.medina@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/lingling.peng@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/nextflow-tester@sagebase.org'
 
     # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
     # - '{{stack_group_config.tower_viewer_arn_prefix}}/rixing.xu@sagebase.org'


### PR DESCRIPTION
This is the same as PR #478 to add a test user for tower-dev which worked successfully.  Now we are adding the same test user for tower (prod) environment.