### PR TITLE
Revert "[IT-2361] Update Seqera enterprise version (#477)"

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v25.2.3
+tower_version: v25.1.5
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
This reverts commit 9c54277d2cbdd67b108e7ea468f28c03c9c0feb7.

Deployment failed with a bunch of "No PropertySource found for file name" errors.