### PR TITLE
Remove email entries from ntap-add5-project.yaml due to 1024 string limit 

### DIFF
--- a/config/projects-prod/ntap-add5-project.yaml
+++ b/config/projects-prod/ntap-add5-project.yaml
@@ -14,8 +14,6 @@ parameters:
     - '{{stack_group_config.tower_viewer_arn_prefix}}/sasha.scott@sagebase.org'
     - "{{stack_group_config.tower_viewer_arn_prefix}}/anh.nguyet.vu@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/belinda.garana@sagebase.org"
-    - "{{stack_group_config.tower_viewer_arn_prefix}}/dan.lu@sagebase.org"
-    - "{{stack_group_config.tower_viewer_arn_prefix}}/bryan.fauble@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/ziwei.pan@sagebase.org"
   AccountAdminArns:
     - "{{stack_group_config.sso_admin_role.arn}}"


### PR DESCRIPTION
Removed email entries for dan.lu and bryan.fauble from the project configuration.