### PR TITLE
[IT-2361] Update Seqera Tower version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v25.1.5
+tower_version: v25.2.1
 default_stack_tags:
   Department: IBC
   Project: Infrastructure

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -268,7 +268,7 @@ Resources:
             - ContainerName: !Ref RedisContainerName
               Condition: START
       {%- endif %}
-          WorkingDirectory: /work
+          WorkingDirectory: "/"   # workaround for IT-2361
           EntryPoint:
             - /bin/sh
           Command:


### PR DESCRIPTION
Update to v25.2.1 with a workaround fix for migrate-db container.