### PR TITLE
[IT-2361] update Seqera tower version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v25.2.1
+tower_version: v25.3.1
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
Update Seqera tower to the latest version v25.3.1

From the release notes[1]:

* This release maintains backward compatibility with version 25.2.x.
* Make a backup of your Platform database prior to upgrade.
* If you are upgrading from a version prior to 25.1, complete all
  intermediate major version upgrades before upgrading to 25.3.
* Ensure that no pipelines are in a running state during this upgrade as active run data may be lost.

[1] https://docs.seqera.io/changelog/seqera-enterprise/v25.3#upgrade-steps