### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install dependencies
-        run: pip install 'py-orca[all]' 'metaflow' 'pyyaml' 's3fs'
+        run: pip install 'py-orca[all]' 'metaflow' 'pyyaml' 's3fs' 'setuptools==81.0.0'
       - name: Checkout py-orca repository
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
the py-orca import "from orca.services.synapse import SynapseOps"
fails with "ModuleNotFoundError: No module named 'pkg_resources'".
This is due to a transitive dependency of setuptools version 82.0.0.
We need to pin to ver 81.0.0 for it to continue working.
