### PR TITLE
[IT-2361] Add a tower project to share CEs

### DIFF
--- a/config/projects-dev/shared-ce-project.yaml
+++ b/config/projects-dev/shared-ce-project.yaml
@@ -1,0 +1,24 @@
+template:
+  path: tower-project.j2
+stack_name: shared-ce-project
+dependencies:
+  - common/nextflow-forge-iam-policy.yaml
+  - common/nextflow-launch-iam-policy.yaml
+
+parameters:
+  S3ReadWriteAccessArns:
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/khai.do@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/nextflow-tester@sagebase.org'
+  AllowSynapseIndexing: Enabled
+  AccountAdminArns:
+    - '{{stack_group_config.sso_admin_role.arn}}'
+    - !stack_output_external sagebase-github-oidc-workflows-dev-nextflow-infra::ProviderRoleArn
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
+  TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
+  TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+
+stack_tags:
+  Department: IBC
+  Project: Infrastructure
+  OwnerEmail: nextflow-admins@sagebase.org
+  CostCenter: NO PROGRAM / 000000


### PR DESCRIPTION
The purpose of this tower project is to allow other tower projects to reference this project's compute environments.  The idea is to conserve CE due to AWS 50 CE max quota. This will allow multiple tower projects to share this project's CEs.