### PR TITLE
[IT-2361] Update bucket policy for shared CEs

### DIFF
--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -356,15 +356,15 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: DenyCrossProjectAccess
-            Effect: Deny
+          - Sid: AllowCrossProjectAccess
+            Effect: Allow
             Principal:
               AWS: "*"
             Action:
               - "s3:*"
             Condition:
               ArnLike:
-                aws:PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/TowerForge-*"
+                aws:PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/TowerForge-*-InstanceRole*"
             Resource:
               - !Sub "arn:aws:s3:::${TowerBucket}"
               - !Sub "arn:aws:s3:::${TowerBucket}/*"
@@ -493,7 +493,7 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: DenyCrossProjectAccess
+          - Sid: AllowCrossProjectAccess
             Effect: Deny
             Principal:
               AWS: "*"
@@ -501,7 +501,7 @@ Resources:
               - "s3:*"
             Condition:
               ArnLike:
-                aws:PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/TowerForge-*"
+                aws:PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/TowerForge-*-InstanceRole*"
             Resource:
               - !Sub "arn:aws:s3:::${TowerScratch}"
               - !Sub "arn:aws:s3:::${TowerScratch}/*"


### PR DESCRIPTION
The current bucket policy is too restrictive to allow nextflow tower to share compute environments.  When running with the restrictive policy we get the following errors when attempting to share compute environments:

Error with the `DenyCrossProjectAccess` statement:
```
ERROR ~ User: arn:aws:sts::035458030717:assumed-role/TowerForge-7KJPCZFW446ldzBjLEvGwy-InstanceRole/i-0983d54f9f3b88583
is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::example-dev-project-tower-scratch/work/"
with an explicit deny in a resource-based policy (Service: S3, Status Code: 403, Request ID: P98KEYXMA8Z3QZ2R,
Extended Request ID: hLS5jmjnuxTJtK7IsOWECFs3pG40a/1XEbY5K9pxSKM+5jtcspawZke3jQ4msQgBZcUlTUX4yuhL4UAGutB/GnUS91m935Ke)
```

Error with the removal of `DenyCrossProjectAccess` statement:
```
ERROR ~ User: arn:aws:sts::035458030717:assumed-role/TowerForge-7KJPCZFW446ldzBjLEvGwy-InstanceRole/i-0a493191af19fa3d2
is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::example-dev-project-tower-scratch/work/"
because no identity-based policy allows the s3:PutObject action (Service: S3, Status Code: 403, Request ID:
TCRVMPHRY4Q99ZAM, Extended Request ID:
```

We need to explicitly allow `aws:PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/TowerForge-*-InstanceRole*"` to access the project buckets.  This instance role is created and managed by nextflow tower.