### PR TITLE
Make sceptre_user_data optional in extract_manual_compute_env

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -300,7 +300,7 @@ class Projects:
         manual_compute_env_per_workspace = dict()
         for config in self.load_projects():
             stack_name = config["stack_name"]
-            manual_compute_envs = config["sceptre_user_data"].get(
+            manual_compute_envs = config.get("sceptre_user_data", {}).get(
                 "ManualComputeEnvs", []
             )
 


### PR DESCRIPTION
Handle cases where sceptre_user_data key doesn't exist in config by using .get() with empty dict default instead of direct key access.