### PR TITLE
[IT-4104] disable all Tower forge user access keys

### DIFF
--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -98,6 +98,7 @@ Resources:
     Type: AWS::IAM::AccessKey
     Properties:
       UserName: !Ref TowerForgeServiceUser
+      Status: Inactive
 
   TowerForgeServiceRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
The AWS `last accessed` info indicates that these user keys are never accessed. I think seqera tower is using roles instead of user keys to access resources.  Disable all user keys to test my theory.