### PR TITLE
[IT-4104] disable Tower wave user access key

### DIFF
--- a/templates/wave-ecr-user.yaml
+++ b/templates/wave-ecr-user.yaml
@@ -47,6 +47,7 @@ Resources:
     Type: 'AWS::IAM::AccessKey'
     Properties:
       UserName: !Ref WaveServiceUser
+      Status: Inactive
 
   WaveServiceUserAccessKeySecret:
     Type: AWS::SecretsManager::Secret


### PR DESCRIPTION
The AWS last accessed info indicates that this user keys is never accessed. We are using the tower wave service, not a self hosted wave service[1] therefore I don't think we need this key. Disable it to test my theory.

[1] https://docs.seqera.io/platform-enterprise/enterprise/configuration/wave