### PR TITLE
[IT-2361] change to unique project names

### DIFF
--- a/config/projects-dev/example-dev-project.yaml
+++ b/config/projects-dev/example-dev-project.yaml
@@ -31,7 +31,7 @@ stack_tags:
 
 sceptre_user_data:
   ManualComputeEnvs:    # use shared-ce-project's forge batch CEs to run pipelines
-    - WorkspaceName: shared-ce-project
-      ComputeEnvName: shared-ce-project-ondemand-v12
-    - WorkspaceName: shared-ce-project
-      ComputeEnvName: shared-ce-project-spot-v12
+    - WorkspaceName: shared-ce-dev-project
+      ComputeEnvName: shared-ce-dev-project-ondemand-v12
+    - WorkspaceName: shared-ce-dev-project
+      ComputeEnvName: shared-ce-dev-project-spot-v12

--- a/config/projects-dev/example-dev-project.yaml
+++ b/config/projects-dev/example-dev-project.yaml
@@ -32,6 +32,6 @@ stack_tags:
 sceptre_user_data:
   ManualComputeEnvs:    # use shared-ce-project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-dev-project
-      ComputeEnvName: shared-ce-dev-project-ondemand-v12
+      ComputeEnvName: shared-ce-dev-project-ondemand-v13
     - WorkspaceName: shared-ce-dev-project
-      ComputeEnvName: shared-ce-dev-project-spot-v12
+      ComputeEnvName: shared-ce-dev-project-spot-v13

--- a/config/projects-dev/shared-ce-dev-project.yaml
+++ b/config/projects-dev/shared-ce-dev-project.yaml
@@ -1,6 +1,6 @@
 template:
   path: tower-project.j2
-stack_name: shared-ce-project
+stack_name: shared-ce-dev-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml
   - common/nextflow-launch-iam-policy.yaml
@@ -13,7 +13,7 @@ parameters:
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'
-    - !stack_output_external sagebase-github-oidc-workflows-prod-nextflow-infra::ProviderRoleArn
+    - !stack_output_external sagebase-github-oidc-workflows-dev-nextflow-infra::ProviderRoleArn
   TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn

--- a/config/projects-prod/shared-ce-prod-project.yaml
+++ b/config/projects-prod/shared-ce-prod-project.yaml
@@ -1,6 +1,6 @@
 template:
   path: tower-project.j2
-stack_name: shared-ce-project
+stack_name: shared-ce-prod-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml
   - common/nextflow-launch-iam-policy.yaml
@@ -13,7 +13,7 @@ parameters:
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'
-    - !stack_output_external sagebase-github-oidc-workflows-dev-nextflow-infra::ProviderRoleArn
+    - !stack_output_external sagebase-github-oidc-workflows-prod-nextflow-infra::ProviderRoleArn
   TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn


### PR DESCRIPTION
The creation of a tower project creates buckets with the same project name. This will cause a conflict because bucket names must be unique across all of S3.  We need to give projects unique names across multiple AWS accounts otherwise S3 will complain that a bucket already exists and cloudformation will fail to deploy.

depends on #527