### PR TITLE
Add support for ignoring projects with ignore flag

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -225,6 +225,8 @@ class Projects:
     def load_projects(self) -> Iterator[dict]:
         """Load all project configuration files from given directory
 
+        Skips projects with 'ignore: true' attribute.
+
         Yields:
             Iterator[dict]:
                 Each element is a parsed YAML file as a dict
@@ -235,6 +237,13 @@ class Projects:
         for config_path in self.list_projects():
             with open(config_path) as config_file:
                 config = yaml.load(config_file, Loader=yaml.Loader)
+
+                # Skip projects with ignore: true
+                if config.get("ignore", False):
+                    stack_name = config.get("stack_name", config_path)
+                    print(f"Skipping ignored project: {stack_name}")
+                    continue
+
                 self.validate_config(config)
                 yield config
 

--- a/config/projects-prod/genie-bpc-project.yaml
+++ b/config/projects-prod/genie-bpc-project.yaml
@@ -1,3 +1,4 @@
+ignore: true
 template:
   path: tower-project.j2
 stack_name: genie-bpc-project


### PR DESCRIPTION
This allows temporarily disabling tower projects without deleting or moving their configuration files, useful for maintenance or troubleshooting specific projects.  It is inline to how sceptre ignores stacks[1]

[1] https://docs.sceptre-project.org/latest/docs/stack_config.html#ignore

depends on #532