### PR TITLE
Protect shared compute environments from cleanup

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -690,10 +690,16 @@ class TowerWorkspace:
         endpoint = "/compute-envs"
         params = {"workspaceId": self.id}
         response = self.tower.request("GET", endpoint, params=params)
+
+        # Build set of manual CE names to protect from cleanup
+        manual_ce_names = {ce["ComputeEnvName"] for ce in self.manual_compute_envs}
+
         for comp_env in response["computeEnvs"]:
             comp_env_id = comp_env["id"]
             comp_env_name = comp_env["name"]
-            if comp_env_name.endswith(CE_VERSION) and self.has_launchers():
+            if (
+                comp_env_name.endswith(CE_VERSION) and self.has_launchers()
+            ) or comp_env_name in manual_ce_names:
                 continue
             delete_endpoint = f"{endpoint}/{comp_env_id}"
             response = self.tower.request("DELETE", delete_endpoint, params=params)

--- a/config/projects-dev/example-dev-project.yaml
+++ b/config/projects-dev/example-dev-project.yaml
@@ -4,6 +4,7 @@ stack_name: example-dev-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml
   - common/nextflow-launch-iam-policy.yaml
+  - projects-dev/shared-ce-dev-project.yaml
 
 parameters:
   S3ReadWriteAccessArns:

--- a/docs/configure-tower-projects.md
+++ b/docs/configure-tower-projects.md
@@ -113,16 +113,12 @@ For each valid project configuration file in the specified directory:
    - Maps `S3ReadWriteAccessArns` users to Tower `maintain` role
    - Maps `S3ReadOnlyAccessArns` users to Tower `view` role
    - If all users are mapped to `view` only (no launchers), compute environments
-     in the workspace will be deactivate and deleted to free up AWS Batch CE
-     capacity
-
-   > [!CAUTION]
-   > If you are using shared compute environments, do not deactivate your workspace
-     doing so will delete the shared compute environment and affect other workspaces
-     that depend on it.
+     in the workspace will be deleted to free up AWS Batch CE capacity, except
+     for any CEs referenced in `ManualComputeEnvs` which are protected from cleanup
 
 4. **Compute Environment Management**
    - Cleans up old compute environments (not matching current `CE_VERSION`)
+   - Compute environments referenced in `ManualComputeEnvs` are protected from cleanup
    - For workspaces with launchers:
      - If `ManualComputeEnvs` is configured: creates manual CEs referencing source CEs
      - Otherwise: creates Batch Forge CEs (SPOT and on-demand)

--- a/docs/project-config-schema.md
+++ b/docs/project-config-schema.md
@@ -123,7 +123,10 @@ ignore: true
 - If `ManualComputeEnvs` is configured, manual CEs referencing the specified
   source CEs are created instead.
 - If no users have launch permissions, no CEs are created and existing CEs are
-  cleaned up.
+  cleaned up, except for CEs referenced in `ManualComputeEnvs` which are
+  protected from cleanup.
+- Old CEs (not matching the current `CE_VERSION`) are automatically cleaned up
+  during each run.
 
 ## Minimal Example
 


### PR DESCRIPTION
Compute environments referenced in ManualComputeEnvs are now excluded from cleanup, preventing accidental deletion of shared CEs that other workspaces depend on.

- Build set of manual CE names and skip them during cleanup
- Update docs to reflect the new cleanup protection behavior
- Remove outdated CAUTION block about shared CE deletion