### PR TITLE
[IT-3968] Create credential using an assumed role

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -618,16 +618,12 @@ class TowerWorkspace:
                 assert cred["provider"] == "aws"
                 assert cred["deleted"] is None
                 return cred["id"]
-        # Otherwise, create a new credentials entry for the project
-        secret_arn = self.stack["TowerForgeServiceUserAccessKeySecretArn"]
-        credentials = self.org.aws.get_secret_value(secret_arn)
+        # Otherwise, create a new credentials entry using role assumption
         data = {
             "credentials": {
                 "name": self.stack_name,
                 "provider": "aws",
                 "keys": {
-                    "accessKey": credentials["aws_access_key_id"],
-                    "secretKey": credentials["aws_secret_access_key"],
                     "assumeRoleArn": self.stack["TowerForgeServiceRoleArn"],
                 },
                 "description": f"Credentials for {self.stack_name}",


### PR DESCRIPTION
The creation of a credential was setup to use both an IAM secret keys and role assumption.  We don't need to use both, the preferable option is to use a role.  This change removes the IAM secret key option.