### PR TITLE
[IT-3968] Remove IAM user and access key

### DIFF
--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -91,14 +91,6 @@ Conditions:
   SynapseIndexingEnabled: !Equals [!Ref AllowSynapseIndexing, "Enabled"]
 
 Resources:
-  TowerForgeServiceUser:
-    Type: AWS::IAM::User
-
-  TowerForgeServiceUserAccessKey:
-    Type: AWS::IAM::AccessKey
-    Properties:
-      UserName: !Ref TowerForgeServiceUser
-
   TowerForgeServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -108,10 +100,6 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Effect: Allow
-            Action: sts:AssumeRole
-            Principal:
-              AWS: !GetAtt TowerForgeServiceUser.Arn
           - Effect: Allow
             Action: sts:AssumeRole
             Principal:
@@ -556,17 +544,6 @@ Resources:
                 - !Sub "arn:aws:s3:::${TowerScratch}/*"
             - !Ref AWS::NoValue
 
-  TowerForgeServiceUserAccessKeySecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: !Sub "AWS credentials for the ${TowerForgeServiceUser} IAM user"
-      SecretString: !Sub >-
-        {
-          "aws_access_key_id":      "${TowerForgeServiceUserAccessKey}",
-          "aws_secret_access_key":  "${TowerForgeServiceUserAccessKey.SecretAccessKey}"
-        }
-      KmsKeyId: !GetAtt EncryptionKeyStack.Outputs.Key
-
 Outputs:
   S3ReadWriteAccessArns:
     Condition: HasS3ReadWriteAccessArns
@@ -599,16 +576,6 @@ Outputs:
     Value: !GetAtt TowerScratch.Arn
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerScratchArn"
-
-  TowerForgeServiceUser:
-    Value: !Ref TowerForgeServiceUser
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceUser"
-
-  TowerForgeServiceUserArn:
-    Value: !GetAtt TowerForgeServiceUser.Arn
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceUserArn"
 
   TowerForgeServiceRole:
     Value: !Ref TowerForgeServiceRole
@@ -654,13 +621,3 @@ Outputs:
     Value: !GetAtt TowerForgeBatchExecutionRole.Arn
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeBatchExecutionRoleArn"
-
-  TowerForgeServiceUserAccessKeySecret:
-    Value: !Sub "${AWS::StackName}-TowerProjectConfiguration"
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceUserAccessKeySecret"
-
-  TowerForgeServiceUserAccessKeySecretArn:
-    Value: !Ref TowerForgeServiceUserAccessKeySecret
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceUserAccessKeySecretArn"


### PR DESCRIPTION
We are now using a role for tower credentials we no longer need the user access keys.
This should also fix issues IT-4104 and IT-4105

depends on #546