### PR TITLE
[IT-3968] Replace IAM user credentials with IAM role assumption for Tower Forge

### DIFF
--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -91,14 +91,6 @@ Conditions:
   SynapseIndexingEnabled: !Equals [!Ref AllowSynapseIndexing, "Enabled"]
 
 Resources:
-  TowerForgeServiceUser:
-    Type: AWS::IAM::User
-
-  TowerForgeServiceUserAccessKey:
-    Type: AWS::IAM::AccessKey
-    Properties:
-      UserName: !Ref TowerForgeServiceUser
-
   TowerForgeServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -107,11 +99,6 @@ Resources:
         - !Ref TowerLaunchPolicyArn
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action: sts:AssumeRole
-            Principal:
-              AWS: !GetAtt TowerForgeServiceUser.Arn
           - Effect: Allow
             Action: sts:AssumeRole
             Principal:
@@ -565,17 +552,6 @@ Resources:
                 - !Sub "arn:aws:s3:::${TowerScratch}/*"
             - !Ref AWS::NoValue
 
-  TowerForgeServiceUserAccessKeySecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: !Sub "AWS credentials for the ${TowerForgeServiceUser} IAM user"
-      SecretString: !Sub >-
-        {
-          "aws_access_key_id":      "${TowerForgeServiceUserAccessKey}",
-          "aws_secret_access_key":  "${TowerForgeServiceUserAccessKey.SecretAccessKey}"
-        }
-      KmsKeyId: !GetAtt EncryptionKeyStack.Outputs.Key
-
 Outputs:
   S3ReadWriteAccessArns:
     Condition: HasS3ReadWriteAccessArns
@@ -608,16 +584,6 @@ Outputs:
     Value: !GetAtt TowerScratch.Arn
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerScratchArn"
-
-  TowerForgeServiceUser:
-    Value: !Ref TowerForgeServiceUser
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceUser"
-
-  TowerForgeServiceUserArn:
-    Value: !GetAtt TowerForgeServiceUser.Arn
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceUserArn"
 
   TowerForgeServiceRole:
     Value: !Ref TowerForgeServiceRole
@@ -663,13 +629,3 @@ Outputs:
     Value: !GetAtt TowerForgeBatchExecutionRole.Arn
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeBatchExecutionRoleArn"
-
-  TowerForgeServiceUserAccessKeySecret:
-    Value: !Sub "${AWS::StackName}-TowerProjectConfiguration"
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceUserAccessKeySecret"
-
-  TowerForgeServiceUserAccessKeySecretArn:
-    Value: !Ref TowerForgeServiceUserAccessKeySecret
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceUserAccessKeySecretArn"

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -99,6 +99,7 @@ Resources:
         - !Ref TowerLaunchPolicyArn
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
+        Statement:
           - Effect: Allow
             Action: sts:AssumeRole
             Principal:
@@ -142,7 +143,7 @@ Resources:
               - Sid: AllowAssumeForgeRole
                 Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Ref TowerForgeServiceRole
+                Resource: !GetAtt TowerForgeServiceRole.Arn
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -104,6 +104,11 @@ Resources:
             Action: sts:AssumeRole
             Principal:
               AWS: !Ref AccountAdminArns
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              AWS:
+                'Fn::ImportValue': !Sub '${AWS::Region}-nextflow-ecs-task-definition-TowerRoleArn'
 
   TowerForgeBatchHeadJobRole:
     Type: AWS::IAM::Role

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -147,6 +147,15 @@ Resources:
       ManagedPolicyArns:
         - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-forge-iam-policy-NextFlowForgePolicyArn
         - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-launch-iam-policy-NextFlowLaunchPolicyArn
+      Policies:
+        - PolicyName: AssumeForgeServiceRole
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AllowAssumeForgeRole
+                Effect: Allow
+                Action: sts:AssumeRole
+                Resource: !Ref TowerForgeServiceRole
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
We are now using a role for tower credentials we no longer need the user access keys. Switch Tower workspace credentials from IAM user access keys to IAM role assumption. The ECS task role (TowerRole) now assumes the per-workspace TowerForgeServiceRole directly via sts:AssumeRole.

This is a redo of PR #547 which failed to deploy with a `Cannot determine region of bucket` error and was reverted in PR #549 

This should also fix issues IT-4104 and IT-4105

depends on #546
