### PR TITLE
[IT-3968] Consolidate tower role

### DIFF
--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -195,10 +195,48 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
         - arn:aws:iam::aws:policy/SecretsManagerReadWrite
 
+  TowerRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      ManagedPolicyArns:
+        - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-forge-iam-policy-NextFlowForgePolicyArn
+        - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-launch-iam-policy-NextFlowLaunchPolicyArn
+      Policies:
+        - PolicyName: AssumeForgeServiceRole
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AllowAssumeForgeRole
+                Effect: Allow
+                Action: sts:AssumeRole
+                Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/*-TowerForgeServiceRole-*'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service: eks.amazonaws.com
+            Action: sts:AssumeRole
+          - Sid: AllowEcsServiceRoleAssumeRole
+            Effect: Allow
+            Principal:
+              AWS:
+                - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-ecs-service-shared-EcsServiceRoleArn
+            Action: sts:AssumeRole
+
   TowerTask:
     Type: AWS::ECS::TaskDefinition
     Properties:
       ExecutionRoleArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/EcsTaskExecutionRole'
+      TaskRoleArn: !GetAtt TowerRole.Arn
       NetworkMode: bridge
       Volumes:
         - Name: !Ref EfsVolumeName
@@ -419,3 +457,8 @@ Outputs:
     Value: !Ref FrontendContainerPort
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-FrontendContainerPort'
+
+  TowerRoleArn:
+    Value: !GetAtt TowerRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-TowerRoleArn'

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -107,8 +107,7 @@ Resources:
           - Effect: Allow
             Action: sts:AssumeRole
             Principal:
-              AWS:
-                'Fn::ImportValue': !Sub '${AWS::Region}-nextflow-ecs-task-definition-TowerRoleArn'
+              AWS: !GetAtt TowerRole.Arn
 
   TowerForgeBatchHeadJobRole:
     Type: AWS::IAM::Role
@@ -134,21 +133,26 @@ Resources:
               Service:
                 - ecs-tasks.amazonaws.com
 
+  TowerRoleAssumePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: AssumeForgeServiceRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowAssumeForgeRole
+            Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !GetAtt TowerForgeServiceRole.Arn
+      Roles:
+        - !Ref TowerRole
+
   TowerRole:
     Type: "AWS::IAM::Role"
     Properties:
       ManagedPolicyArns:
         - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-forge-iam-policy-NextFlowForgePolicyArn
         - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-launch-iam-policy-NextFlowLaunchPolicyArn
-      Policies:
-        - PolicyName: AssumeForgeServiceRole
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Sid: AllowAssumeForgeRole
-                Effect: Allow
-                Action: sts:AssumeRole
-                Resource: !GetAtt TowerForgeServiceRole.Arn
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -107,7 +107,8 @@ Resources:
           - Effect: Allow
             Action: sts:AssumeRole
             Principal:
-              AWS: !GetAtt TowerRole.Arn
+              AWS:
+                'Fn::ImportValue': !Sub '${AWS::Region}-nextflow-ecs-task-definition-TowerRoleArn'
 
   TowerForgeBatchHeadJobRole:
     Type: AWS::IAM::Role
@@ -132,53 +133,6 @@ Resources:
             Principal:
               Service:
                 - ecs-tasks.amazonaws.com
-
-  TowerRoleAssumePolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: AssumeForgeServiceRole
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: AllowAssumeForgeRole
-            Effect: Allow
-            Action: sts:AssumeRole
-            Resource: !GetAtt TowerForgeServiceRole.Arn
-      Roles:
-        - !Ref TowerRole
-
-  TowerRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      ManagedPolicyArns:
-        - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-forge-iam-policy-NextFlowForgePolicyArn
-        - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-launch-iam-policy-NextFlowLaunchPolicyArn
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: ec2.amazonaws.com
-            Action: sts:AssumeRole
-          - Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-            Action: sts:AssumeRole
-          - Effect: Allow
-            Principal:
-              Service: eks.amazonaws.com
-            Action: sts:AssumeRole
-          - Sid: AllowEc2AssumeRole
-            Effect: Allow
-            Principal:
-              AWS: !Ref AccountAdminArns
-            Action: sts:AssumeRole
-          - Sid: AllowEcsServiceRole2AssumeRole
-            Effect: Allow
-            Principal:
-              AWS:
-                - 'Fn::ImportValue': !Sub ${AWS::Region}-nextflow-ecs-service-shared-EcsServiceRoleArn
-            Action: sts:AssumeRole
 
   TowerForgeBatchHeadJobPolicy:
     Type: AWS::IAM::Policy
@@ -604,11 +558,6 @@ Outputs:
     Value: !GetAtt TowerForgeServiceRole.Arn
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerForgeServiceRoleArn"
-
-  TowerRoleArn:
-    Value: !GetAtt TowerRole.Arn
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-TowerRoleArn"
 
   TowerForgeBatchHeadJobRole:
     Value: !Ref TowerForgeBatchHeadJobRole


### PR DESCRIPTION
Consolidate the TowerRole IAM resource into the ECS task definition
stack so it can be associated to the ECS backend execution task.
This will also allow us to create the resource once and shared it across
all project workspaces.
