### PR TITLE
[IT-3968] Fix strides ampad deployment

### DIFF
--- a/config/projects-ampad/agora-project.yaml
+++ b/config/projects-ampad/agora-project.yaml
@@ -23,6 +23,7 @@ parameters:
   TemplateRootUrl: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com"
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+  TowerRoleArn: "arn:aws:iam::728882028485:role/nextflow-ecs-task-definition-TowerRole-9mvcdEHKSUe3"
 
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-ampad/diverse-cohorts-project.yaml
+++ b/config/projects-ampad/diverse-cohorts-project.yaml
@@ -19,6 +19,7 @@ parameters:
   TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+  TowerRoleArn: "arn:aws:iam::728882028485:role/nextflow-ecs-task-definition-TowerRole-9mvcdEHKSUe3"
 
 stack_tags:
   Department: NDR

--- a/config/projects-ampad/example-ampad-project.yaml
+++ b/config/projects-ampad/example-ampad-project.yaml
@@ -14,6 +14,7 @@ parameters:
   TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+  TowerRoleArn: "arn:aws:iam::728882028485:role/nextflow-ecs-task-definition-TowerRole-9mvcdEHKSUe3"
 
 stack_tags:
   Department: IBC

--- a/config/projects-ampad/jared-hendrickson-project.yaml
+++ b/config/projects-ampad/jared-hendrickson-project.yaml
@@ -17,6 +17,7 @@ parameters:
   TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+  TowerRoleArn: "arn:aws:iam::728882028485:role/nextflow-ecs-task-definition-TowerRole-9mvcdEHKSUe3"
 
 stack_tags:
   Department: NDR

--- a/config/projects-ampad/model-ad-rna-project.yaml
+++ b/config/projects-ampad/model-ad-rna-project.yaml
@@ -19,6 +19,7 @@ parameters:
   TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+  TowerRoleArn: "arn:aws:iam::728882028485:role/nextflow-ecs-task-definition-TowerRole-9mvcdEHKSUe3"
 
 stack_tags:
   Department: NDR

--- a/config/projects-ampad/strides-ampad-project.yaml
+++ b/config/projects-ampad/strides-ampad-project.yaml
@@ -19,6 +19,7 @@ parameters:
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
   EnableScratchDataExpiration: Disabled
+  TowerRoleArn: "arn:aws:iam::728882028485:role/nextflow-ecs-task-definition-TowerRole-9mvcdEHKSUe3"
 
 stack_tags:
   Department: NDR

--- a/config/projects-ampad/wei-an-chen-project.yaml
+++ b/config/projects-ampad/wei-an-chen-project.yaml
@@ -16,6 +16,7 @@ parameters:
   TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+  TowerRoleArn: "arn:aws:iam::728882028485:role/nextflow-ecs-task-definition-TowerRole-9mvcdEHKSUe3"
 
 stack_tags:
   Department: NDR

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -83,12 +83,18 @@ Parameters:
     Type: String
     Description: ARN for Tower Launch IAM policy
 
+  TowerRoleArn:
+    Type: String
+    Default: ""
+    Description: ARN of the TowerRole from the ECS task definition stack. If empty, imports from the default stack.
+
 Conditions:
   HasS3ReadWriteAccessArns:
     !Not [!Equals [!Join [",", !Ref S3ReadWriteAccessArns], ""]]
   HasS3ReadOnlyAccessArns:
     !Not [!Equals [!Join [",", !Ref S3ReadOnlyAccessArns], ""]]
   SynapseIndexingEnabled: !Equals [!Ref AllowSynapseIndexing, "Enabled"]
+  HasTowerRoleArn: !Not [!Equals [!Ref TowerRoleArn, ""]]
 
 Resources:
   TowerForgeServiceRole:
@@ -107,8 +113,10 @@ Resources:
           - Effect: Allow
             Action: sts:AssumeRole
             Principal:
-              AWS:
-                'Fn::ImportValue': !Sub '${AWS::Region}-nextflow-ecs-task-definition-TowerRoleArn'
+              AWS: !If
+                - HasTowerRoleArn
+                - !Ref TowerRoleArn
+                - 'Fn::ImportValue': !Sub '${AWS::Region}-nextflow-ecs-task-definition-TowerRoleArn'
 
   TowerForgeBatchHeadJobRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
The project deployments to strides amapad workflow account failed because the TowerRoleArn was moved to nextflow-ecs-task-definition template in PR #552 which broke the reference in tower-project.2 templates.  This attempts to fix the broken reference.

This change parameterizes TowerRoleArn and by default (in prod env) it will reference the Tower role in the account.  If it's deployed to a different account then Tower role ARN needs to be manually looked up and passed in as a literal string.