### PR TITLE
[IT-3968] Fix cross account access

### DIFF
--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -209,7 +209,9 @@ Resources:
               - Sid: AllowAssumeForgeRole
                 Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/*-TowerForgeServiceRole-*'
+                Resource:
+                  - !Sub 'arn:aws:iam::${AWS::AccountId}:role/*-TowerForgeServiceRole-*'
+                  - 'arn:aws:iam::751556145034:role/*-TowerForgeServiceRole-*'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
Creation of compute environment was failing for projects deployed to strides ampad account due to cross account access.  This fixes that issue by allowing tower in strides ampad account to access the ECS resources in the prod account.