### PR TITLE
[DPE-1657] Change integration test's Python version from 3.12 to 3.11

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Install dependencies
         run: pip install 'py-orca[all]' 'metaflow' 'pyyaml' 's3fs' 'setuptools==81.0.0'
       - name: Checkout py-orca repository


### PR DESCRIPTION
## Problem

The [latest version](https://pypi.org/project/py-orca/1.5.3/) of `py-orca` on PyPI requires installation in an environment that has python versions `>=3.10` or `<3.12`:

```
(pyorca-may13) bash-3.2$ pip install py-orca==1.5.3
ERROR: Ignored the following versions that require a different python version: 1.3.4 Requires-Python >=3.10,<3.12; 1.3.5 Requires-Python >=3.10,<3.12; 1.4.0 Requires-Python >=3.10,<3.12; 1.5.0 Requires-Python >=3.10,<3.12; 1.5.1 Requires-Python >=3.10,<3.12; 1.5.2 Requires-Python >=3.10,<3.12; 1.5.3 Requires-Python >=3.10,<3.12
ERROR: Could not find a version that satisfies the requirement py-orca==1.5.3 (from versions: 1.0.0, 1.0.1, 1.1.0, 1.2.0, 1.3.0, 1.3.1, 1.3.2, 1.3.3)
ERROR: No matching distribution found for py-orca==1.5.3
```

This latest version of `py-orca` contains an update in the way the response JSONs are handled from Nextflow Tower's `/workflow` API (see more context in [this PR](https://github.com/Sage-Bionetworks-Workflows/py-orca/pull/53)). The integration test here needs this latest version of `py-orca` to run successfully, otherwise it fails with a similar error to the one below:

```
2026-05-12 21:34:37.059 [1778621663411628/launch_synstage/5 (pid 2444)] TypeError: object of type 'bool' has no len()
2026-05-12 21:34:37.059 [1778621663411628/launch_synstage/5 (pid 2444)] 
    Step failure:
    Step launch_synstage (task-id 5) failed.
```

## Solution

Since the `deployment-validation` job centers around installing `py-orca` and running a version of the `demo.py` script in that repository, the best solution is to change the python version of the environment in which this job runs, rather than changing the python version restriction in `py-orca` itself.

## Testing

I can confirm that working in a `3.11` environment allows for the latest version of `py-orca` to be installed when using `pip install py-orca[all]`:

```
(base) bash-3.2$ conda activate pyorca-311
(pyorca-311) bash-3.2$ pip install py-orca[all]
Collecting py-orca[all]
  Downloading py_orca-1.5.3-py3-none-any.whl.metadata (8.3 kB)
```