### PR TITLE
[IT-5068] Deploy nextflow infra on Sagebrain

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -36,12 +36,3 @@ jobs:
       sceptre-suffix: "ampad"
       tower-url: "https://tower.sagebionetworks.org"
       aws-role-to-assume: "arn:aws:iam::751556145034:role/github-oidc-nextflow-infra"
-  deploy-sagebrain:
-    needs: deploy-prod
-    uses: "./.github/workflows/rw-deploy.yaml"
-    secrets: inherit
-    with:
-      job-environment: "org-sagebase-sagebrain-workflows"
-      sceptre-suffix: "sagebrain"
-      tower-url: "https://tower.sagebionetworks.org"
-      aws-role-to-assume: "arn:aws:iam::620117233256:role/github-oidc-nextflow-infra"

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -36,3 +36,12 @@ jobs:
       sceptre-suffix: "ampad"
       tower-url: "https://tower.sagebionetworks.org"
       aws-role-to-assume: "arn:aws:iam::751556145034:role/github-oidc-nextflow-infra"
+  deploy-sagebrain:
+    needs: deploy-prod
+    uses: "./.github/workflows/rw-deploy.yaml"
+    secrets: inherit
+    with:
+      job-environment: "org-sagebase-sagebrain-workflows"
+      sceptre-suffix: "sagebrain"
+      tower-url: "https://tower.sagebionetworks.org"
+      aws-role-to-assume: "arn:aws:iam::620117233256:role/github-oidc-nextflow-infra"

--- a/config/infra-sagebrain/config.yaml
+++ b/config/infra-sagebrain/config.yaml
@@ -1,0 +1,2 @@
+sso_admin_role:
+  arn: arn:aws:iam::620117233256:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_796a395ce7a0eea6

--- a/config/infra-sagebrain/nextflow-s3-vpc-endpoint.yaml
+++ b/config/infra-sagebrain/nextflow-s3-vpc-endpoint.yaml
@@ -1,0 +1,13 @@
+template:
+  type: http
+  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.3.2/templates/gateway-vpc-endpoint.yaml"
+stack_name: nextflow-s3-vpc-endpoint
+dependencies:
+  - infra-ampad/nextflow-vpc.yaml
+
+parameters:
+  VpcName: "nextflow-vpc"
+  ServiceName: "com.amazonaws.us-east-1.s3"
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/config/infra-sagebrain/nextflow-s3-vpc-endpoint.yaml
+++ b/config/infra-sagebrain/nextflow-s3-vpc-endpoint.yaml
@@ -3,7 +3,7 @@ template:
   url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.3.2/templates/gateway-vpc-endpoint.yaml"
 stack_name: nextflow-s3-vpc-endpoint
 dependencies:
-  - infra-ampad/nextflow-vpc.yaml
+  - infra-sagebrain/nextflow-vpc.yaml
 
 parameters:
   VpcName: "nextflow-vpc"

--- a/config/infra-sagebrain/nextflow-vpc.yaml
+++ b/config/infra-sagebrain/nextflow-vpc.yaml
@@ -1,0 +1,11 @@
+template:
+  type: http
+  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.3.0/templates/VPC/vpc-20-private.yaml"
+stack_name: nextflow-vpc
+
+parameters:
+  VpcName: nextflow-vpc
+  VpcSubnetPrefix: "172.20"
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/config/infra-sagebrain/wave-ecr-user.yaml
+++ b/config/infra-sagebrain/wave-ecr-user.yaml
@@ -1,0 +1,9 @@
+template:
+  path: wave-ecr-user.yaml
+stack_name: wave-ecr-user
+
+dependencies:
+  - infra-ampad/workflows-kms-key.yaml
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/config/infra-sagebrain/wave-ecr-user.yaml
+++ b/config/infra-sagebrain/wave-ecr-user.yaml
@@ -3,7 +3,7 @@ template:
 stack_name: wave-ecr-user
 
 dependencies:
-  - infra-ampad/workflows-kms-key.yaml
+  - infra-sagebrain/workflows-kms-key.yaml
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}

--- a/config/infra-sagebrain/workflows-kms-key.yaml
+++ b/config/infra-sagebrain/workflows-kms-key.yaml
@@ -6,7 +6,7 @@ parameters:
   TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
   AccountAdminArns:
     - {{stack_group_config.sso_admin_role.arn}}
-    - !stack_output_external github-oidc-nextflow-infra::ProviderRoleArn
+    - !stack_output_external sagebase-github-oidc-sage-bionetworks-it-sagebrain-infra::ProviderRoleArn
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}

--- a/config/infra-sagebrain/workflows-kms-key.yaml
+++ b/config/infra-sagebrain/workflows-kms-key.yaml
@@ -1,0 +1,12 @@
+template:
+  path: workflows-kms-key.yaml
+stack_name: workflows-infra-kms-key
+
+parameters:
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
+  AccountAdminArns:
+    - {{stack_group_config.sso_admin_role.arn}}
+    - !stack_output_external github-oidc-nextflow-infra::ProviderRoleArn
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}


### PR DESCRIPTION
Setup nextflow infrastructure in the org-sagebase-sagebrain AWS
account.

All files are copied from config/infra-sagebrain directory with slight
updates for the new account.
