### PR TITLE
[IT-5068] Decouple deployments

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -7,15 +7,23 @@ on:
       - '**.md'
 
 jobs:
-  deploy-dev:
-    uses: "./.github/workflows/rw-deploy.yaml"
+  deploy-infra:
+    uses: "./.github/workflows/rw-deploy-infra.yaml"
+    secrets: inherit
+    with:
+      job-environment: "workflows-nextflow-dev"
+      sceptre-suffix: "dev"
+      aws-role-to-assume: "arn:aws:iam::035458030717:role/sagebase-github-oidc-workflows-dev-nextflow-infra"
+      aws-assume-role-duration: 3600
+  deploy-projects:
+    uses: "./.github/workflows/rw-deploy-projects.yaml"
     secrets: inherit
     with:
       job-environment: "workflows-nextflow-dev"
       sceptre-suffix: "dev"
       tower-url: "https://tower-dev.sagebionetworks.org"
       aws-role-to-assume: "arn:aws:iam::035458030717:role/sagebase-github-oidc-workflows-dev-nextflow-infra"
-      aws-assume-role-duration: 7200
+      aws-assume-role-duration: 3600
   deployment-validation:
     needs: deploy-dev
     uses: "./.github/workflows/integration-test.yaml"

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -7,7 +7,15 @@ on:
       - '**.md'
 
 jobs:
-  deploy-prod:
+  deploy-infra:
+    uses: "./.github/workflows/rw-deploy.yaml"
+    secrets: inherit
+    with:
+      job-environment: "workflows-nextflow-prod"
+      sceptre-suffix: "prod"
+      aws-role-to-assume: "arn:aws:iam::728882028485:role/sagebase-github-oidc-workflows-prod-nextflow-infra"
+      aws-assume-role-duration: 3600
+  deploy-projects:
     uses: "./.github/workflows/rw-deploy.yaml"
     secrets: inherit
     with:
@@ -15,7 +23,7 @@ jobs:
       sceptre-suffix: "prod"
       tower-url: "https://tower.sagebionetworks.org"
       aws-role-to-assume: "arn:aws:iam::728882028485:role/sagebase-github-oidc-workflows-prod-nextflow-infra"
-      aws-assume-role-duration: 7200
+      aws-assume-role-duration: 3600
   deployment-validation:
     needs: deploy-prod
     uses: "./.github/workflows/integration-test.yaml"

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy-infra:
-    uses: "./.github/workflows/rw-deploy.yaml"
+    uses: "./.github/workflows/rw-deploy-infra.yaml"
     secrets: inherit
     with:
       job-environment: "workflows-nextflow-prod"
@@ -16,7 +16,7 @@ jobs:
       aws-role-to-assume: "arn:aws:iam::728882028485:role/sagebase-github-oidc-workflows-prod-nextflow-infra"
       aws-assume-role-duration: 3600
   deploy-projects:
-    uses: "./.github/workflows/rw-deploy.yaml"
+    uses: "./.github/workflows/rw-deploy-projects.yaml"
     secrets: inherit
     with:
       job-environment: "workflows-nextflow-prod"

--- a/.github/workflows/rw-deploy-infra.yaml
+++ b/.github/workflows/rw-deploy-infra.yaml
@@ -8,9 +8,6 @@ on:
       sceptre-suffix:
         required: true
         type: string
-      tower-url:
-        required: true
-        type: string
       aws-role-to-assume:
         required: true
         type: string
@@ -58,22 +55,3 @@ jobs:
         run: >
           pipenv run sceptre --var-file=src/sceptre/variables/${{ inputs.sceptre-suffix }}.yaml
           launch infra-${{ inputs.sceptre-suffix }} --yes --prune
-
-      - name: Deploy projects configuration
-        run: >
-          pipenv run sceptre --var-file=src/sceptre/variables/${{ inputs.sceptre-suffix }}.yaml
-          launch projects-${{ inputs.sceptre-suffix }} --yes --prune
-
-      - name: Wait for Nextflow Tower to be up
-        uses: nev7n/wait_for_response@v1
-        with:
-          url: ${{ inputs.tower-url }}
-          responseCode: 200
-          timeout: 1800000  # 30 minutes
-          interval: 30000   # 30 seconds
-
-      - name: Configure projects in Tower
-        run: pipenv run bin/configure-tower-projects.py config/projects-${{ inputs.sceptre-suffix }}
-        env:
-          NXF_TOWER_TOKEN: ${{ secrets.TOWER_TOKEN }}
-          NXF_TOWER_API_URL: ${{ inputs.tower-url }}/api

--- a/.github/workflows/rw-deploy-infra.yaml
+++ b/.github/workflows/rw-deploy-infra.yaml
@@ -47,11 +47,15 @@ jobs:
           role-duration-seconds: ${{ inputs.aws-assume-role-duration }}
 
       - name: Deploy common configuration
+        env:
+          SCEPTRE_SUFFIX: ${{ inputs.sceptre-suffix }}
         run: >
-          pipenv run sceptre --var-file=src/sceptre/variables/${{ inputs.sceptre-suffix }}.yaml
+          pipenv run sceptre --var-file=src/sceptre/variables/${SCEPTRE_SUFFIX}.yaml
           launch common --yes --prune
 
       - name: Deploy infrastructure configuration
+        env:
+          SCEPTRE_SUFFIX: ${{ inputs.sceptre-suffix }}
         run: >
-          pipenv run sceptre --var-file=src/sceptre/variables/${{ inputs.sceptre-suffix }}.yaml
-          launch infra-${{ inputs.sceptre-suffix }} --yes --prune
+          pipenv run sceptre --var-file=src/sceptre/variables/${SCEPTRE_SUFFIX}.yaml
+          launch infra-${SCEPTRE_SUFFIX} --yes --prune

--- a/.github/workflows/rw-deploy-projects.yaml
+++ b/.github/workflows/rw-deploy-projects.yaml
@@ -1,0 +1,69 @@
+name: rw-deploy
+on:
+  workflow_call:
+    inputs:
+      job-environment:
+        required: true
+        type: string
+      sceptre-suffix:
+        required: true
+        type: string
+      tower-url:
+        required: true
+        type: string
+      aws-role-to-assume:
+        required: true
+        type: string
+      aws-assume-role-duration:
+        required: false
+        type: number
+        default: 3600
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.job-environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pipenv
+        run: pip install -U pipenv
+
+      - name: Install dependencies
+        run: pipenv install --dev
+
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ inputs.aws-role-to-assume }}
+          role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-duration-seconds: ${{ inputs.aws-assume-role-duration }}
+
+      - name: Deploy projects configuration
+        run: >
+          pipenv run sceptre --var-file=src/sceptre/variables/${{ inputs.sceptre-suffix }}.yaml
+          launch projects-${{ inputs.sceptre-suffix }} --yes --prune
+
+      - name: Wait for Nextflow Tower to be up
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: ${{ inputs.tower-url }}
+          responseCode: 200
+          timeout: 1800000  # 30 minutes
+          interval: 30000   # 30 seconds
+
+      - name: Configure projects in Tower
+        run: pipenv run bin/configure-tower-projects.py config/projects-${{ inputs.sceptre-suffix }}
+        env:
+          NXF_TOWER_TOKEN: ${{ secrets.TOWER_TOKEN }}
+          NXF_TOWER_API_URL: ${{ inputs.tower-url }}/api


### PR DESCRIPTION
Decouple infra deployments from seqera tower project deployments in Github actions.  This makes it easier to manage deployments when adding or removing components.