### PR TITLE
[IT-5068] Give tower forge in sagebrain access

### DIFF
--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -29,6 +29,9 @@ parameters:
     - thomas.yu@sagebase.org
     - khai.do@sagebase.org
   TowerConfigFileName: 'tower.yaml'
+  ExternalTowerForgeRoles:
+    - "arn:aws:iam::751556145034:role/*-TowerForgeServiceRole-*"   # ampad
+    - "arn:aws:iam::620117233256:role/*-TowerForgeServiceRole-*"   # sagebrain
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -198,6 +198,7 @@ Resources:
                 Resource:
                   - !Sub 'arn:aws:iam::${AWS::AccountId}:role/*-TowerForgeServiceRole-*'
                   - 'arn:aws:iam::751556145034:role/*-TowerForgeServiceRole-*'
+                  - 'arn:aws:iam::620117233256:role/*-TowerForgeServiceRole-*'
         - PolicyName: SESEmailAccess
           PolicyDocument:
             Version: '2012-10-17'

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -156,9 +156,16 @@ Parameters:
     Type: String
     Description: Prefix used for CloudWatch log streams
     Default: 'tower'
+  ExternalTowerForgeRoles:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >
+      Comma-separated list of external TowerForgeServiceRole ARN patterns
+      that the TowerRole is allowed to assume (e.g., for cross-account access)
 Conditions:
   HasTowerOidcClient: !Not [!Equals [ !Ref TowerOidcClientId, "NULL"]]
   HasTowerRootUsers: !Not [!Equals [!Join [",", !Ref TowerRootUsers], ""]]
+  HasExternalTowerForgeRoles: !Not [!Equals [!Join [",", !Ref ExternalTowerForgeRoles], ""]]
 Resources:
   TowerTaskLogGroup:
     Type: AWS::Logs::LogGroup
@@ -197,8 +204,13 @@ Resources:
                 Action: sts:AssumeRole
                 Resource:
                   - !Sub 'arn:aws:iam::${AWS::AccountId}:role/*-TowerForgeServiceRole-*'
-                  - 'arn:aws:iam::751556145034:role/*-TowerForgeServiceRole-*'
-                  - 'arn:aws:iam::620117233256:role/*-TowerForgeServiceRole-*'
+              - !If
+                - HasExternalTowerForgeRoles
+                - Sid: AllowAssumeExternalForgeRole
+                  Effect: Allow
+                  Action: sts:AssumeRole
+                  Resource: !Ref ExternalTowerForgeRoles
+                - !Ref AWS::NoValue
         - PolicyName: SESEmailAccess
           PolicyDocument:
             Version: '2012-10-17'


### PR DESCRIPTION
Allow tower forge in Sagebrain account to assume the required role in workflows account