### PR TITLE
[IT-5068] update github action role

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -54,4 +54,4 @@ jobs:
       job-environment: "org-sagebase-sagebrain-workflows"
       sceptre-suffix: "sagebrain"
       tower-url: "https://tower.sagebionetworks.org"
-      aws-role-to-assume: "arn:aws:iam::620117233256:role/sagebase-github-oidc-sage-bionetworks-it-sagebrain-infra"
+      aws-role-to-assume: "arn:aws:iam::620117233256:role/sagebase-github-oidc-workflows-prod-nextflow-infra"


### PR DESCRIPTION
The sagebrain deployment was set to the wrong role, update to the correct role.

depends on https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/1612