### PR TITLE
[IT-5155] Update to use new Seqera image registry

### DIFF
--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -18,10 +18,10 @@ parameters:
   TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-migration-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
-  CronContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
-  FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
-  BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
-  MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
+  CronContainerImage: 'cr.seqera.io/enterprise/platform/backend:{{stack_group_config.tower_version}}'
+  FrontendContainerImage: 'cr.seqera.io/enterprise/platform/frontend:{{stack_group_config.tower_version}}'
+  BackendContainerImage: 'cr.seqera.io/enterprise/platform/backend:{{stack_group_config.tower_version}}'
+  MigrateDBContainerImage: 'cr.seqera.io/enterprise/platform/migrate-db:{{stack_group_config.tower_version}}'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerUserWorkspace: 'true'

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -18,10 +18,10 @@ parameters:
   TowerDbPassword: !aws_secrets_manager nextflow-aurora-mysql-migration-NextflowTowerDatabaseUserSecret::SecretString::password
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
-  CronContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
-  FrontendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/frontend:{{stack_group_config.tower_version}}'
-  BackendContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/backend:{{stack_group_config.tower_version}}'
-  MigrateDBContainerImage: 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:{{stack_group_config.tower_version}}'
+  CronContainerImage: 'cr.seqera.io/enterprise/platform/backend:{{stack_group_config.tower_version}}'
+  FrontendContainerImage: 'cr.seqera.io/enterprise/platform/frontend:{{stack_group_config.tower_version}}'
+  BackendContainerImage: 'cr.seqera.io/enterprise/platform/backend:{{stack_group_config.tower_version}}'
+  MigrateDBContainerImage: 'cr.seqera.io/enterprise/platform/migrate-db:{{stack_group_config.tower_version}}'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerUserWorkspace: 'true'

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -77,7 +77,7 @@ Parameters:
     Type: String
     Description: >
       (Optional) migrate-db container docker image,
-      e.g. 'cr.seqera.io/private/nf-tower-enterprise/migrate-db:v23.4.3'
+      e.g. 'cr.seqera.io/enterprise/platform/migrate-db:v23.4.3'
   CronContainerName:
     Type: String
     Description: (Optional) Name of the cron container
@@ -86,7 +86,7 @@ Parameters:
     Type: String
     Description: >
       (Optional) Cron container docker image,
-      e.g. 'cr.seqera.io/private/nf-tower-enterprise/backend:v21.06.0'
+      e.g. 'cr.seqera.io/enterprise/platform/backend:v21.06.0'
   FrontendContainerName:
     Type: String
     Description: (Optional) Name of the container that runs the tower ui
@@ -95,7 +95,7 @@ Parameters:
     Type: String
     Description: >
       Frontend container docker image,
-      e.g. 'cr.seqera.io/private/nf-tower-enterprise/frontend:v21.06.0'
+      e.g. 'cr.seqera.io/enterprise/platform/frontend:v21.06.0'
   FrontendContainerPort:
     Type: Number
     Description: (Optional) Port to open in frontend container
@@ -112,7 +112,7 @@ Parameters:
     Type: String
     Description: >
       Backend container docker image,
-      e.g. 'cr.seqera.io/private/nf-tower-enterprise/backend:v21.06.0'
+      e.g. 'cr.seqera.io/enterprise/platform/backend:v21.06.0'
   BackendContainerPort:
     Type: Number
     Description: (Optional) Port to open in backend container


### PR DESCRIPTION
All occurrences of cr.seqera.io/private/nf-tower-enterprise/
have been replaced with cr.seqera.io/enterprise/platform/

Note: The RepositoryCredentials reference TOWER_DEV_SEQERA_REGISTRY_SECRET
in Secrets Manager will need to contain valid credentials for the new cr.seqera.io/enterprise registry.