### PR TITLE
Grant head-job role secretsmanager:GetSecretValue on tower-* secrets

### DIFF
--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -179,6 +179,11 @@ Resources:
             Resource:
               - !GetAtt TowerForgeBatchWorkJobRole.Arn
               - !GetAtt TowerForgeBatchExecutionRole.Arn
+          - Sid: HeadJobSecretAccess
+            Effect: Allow
+            Action:
+              - secretsmanager:GetSecretValue
+            Resource: "arn:aws:secretsmanager:*:*:secret:tower-*"
       Roles:
         - !Ref TowerForgeBatchHeadJobRole
 


### PR DESCRIPTION
The `TowerForgeBatchHeadJobRole` policy (`TowerForgeBatchHeadJobPolicy` in `templates/tower-project.j2`) grants only `secretsmanager:ListSecrets`. Secret **values** are readable only by `TowerForgeBatchExecutionRole` (`secretsmanager:GetSecretValue` on `tower-*`), which injects them as env vars into **task** containers.

That matches Seqera's documented least-privilege model, but it assumes secrets are only ever consumed **inside processes/tasks**. It breaks for plugins that resolve authenticated `file()` URIs in the **head job**, where samplesheet validation (nf-schema `exists`/format checks) and FilePorter foreign-file staging both run *before any task starts*.

Two Sage-owned filesystem plugins hit this:

| Plugin | URI | Token |
|---|---|---|
| [nf-synapse](https://github.com/Sage-Bionetworks-Workflows/nf-synapse-plugin) | `syn://` | `SYNAPSE_AUTH_TOKEN` |
| [nf-drs](https://github.com/Sage-Bionetworks-Workflows/nf-drs) | `drs://` | `GEN3_API_KEY` |

Both read the token via `SecretsLoader.instance.load().getSecret()`, which on AWS Batch performs a **direct Secrets Manager `GetSecretValue` from the head job**. This is denied by the current policy. Observed failure:

```
User: ...TowerForgeBatchHeadJobRole... is not authorized to perform:
secretsmanager:GetSecretValue on resource: tower-<runId>/SYNAPSE_AUTH_TOKEN
```

When the plugin swallows the denial it instead reports the misleading `Synapse authentication token not configured`.

This PR adds a `GetSecretValue` statement to `TowerForgeBatchHeadJobPolicy`, scoped to `secret:tower-*`, identical scope to the execution role:


Scope is limited to run-scoped Platform secrets (`tower-*`), which Seqera auto-creates and deletes per run so no standing access to other secrets.