### PR TITLE
[IT-5155] Update seqera tower version (#582)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v25.3.4
+tower_version: v26.1.3
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
Seqera docs says we can do a direct upgrade from v25.3.x [1].

This is a redo of PR #582. Not sure why but v26.1 is no longer available so
we will attempt an update to v26.1.3 

[1] https://docs.seqera.io/platform-enterprise/enterprise/upgrade#upgrading-from-version-253x-to-261
