### PR TITLE
[IT-5235] Bump CE_VERSION v13 -> v14 to deploy g5 GPU instances

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -904,8 +904,6 @@ class TowerWorkspace:
                             "configMode": "Manual",
                             "headQueue": source_ce_head_queue,
                             "computeQueue": source_ce_compute_queue,
-                            "headJobCpus": 8,
-                            "headJobMemoryMb": 15000,
                             "cliPath": "/home/ec2-user/miniconda/bin/aws",
                             "resourceLabelIds": label_ids,
                             "executionRole": source_ce_execution_role,

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -904,6 +904,8 @@ class TowerWorkspace:
                             "configMode": "Manual",
                             "headQueue": source_ce_head_queue,
                             "computeQueue": source_ce_compute_queue,
+                            "headJobCpus": 8,
+                            "headJobMemoryMb": 15000,
                             "cliPath": "/home/ec2-user/miniconda/bin/aws",
                             "resourceLabelIds": label_ids,
                             "executionRole": source_ce_execution_role,

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -15,7 +15,7 @@ import yaml  # type: ignore
 from sagetasks.nextflowtower.client import TowerClient  # type: ignore
 
 # Increment this version when updating compute environments
-CE_VERSION = "v13"
+CE_VERSION = "v14"
 
 REGION = "us-east-1"
 ORG_NAME = "Sage Bionetworks"

--- a/config/projects-dev/example-dev-project.yaml
+++ b/config/projects-dev/example-dev-project.yaml
@@ -33,6 +33,6 @@ stack_tags:
 sceptre_user_data:
   ManualComputeEnvs:    # use shared-ce-project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-dev-project
-      ComputeEnvName: shared-ce-dev-project-ondemand-v13
+      ComputeEnvName: shared-ce-dev-project-ondemand-v14
     - WorkspaceName: shared-ce-dev-project
-      ComputeEnvName: shared-ce-dev-project-spot-v13
+      ComputeEnvName: shared-ce-dev-project-spot-v14

--- a/config/projects-prod/ampra-project.yaml
+++ b/config/projects-prod/ampra-project.yaml
@@ -63,6 +63,6 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/config/projects-prod/complementaire-project.yaml
+++ b/config/projects-prod/complementaire-project.yaml
@@ -9,9 +9,9 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14
 
 parameters:
   S3ReadWriteAccessArns:

--- a/config/projects-prod/ctf-swnts-project.yaml
+++ b/config/projects-prod/ctf-swnts-project.yaml
@@ -52,6 +52,6 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/config/projects-prod/example-project.yaml
+++ b/config/projects-prod/example-project.yaml
@@ -68,6 +68,6 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/config/projects-prod/iatlas-project.yaml
+++ b/config/projects-prod/iatlas-project.yaml
@@ -37,6 +37,6 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/config/projects-prod/jhu-ras-pathway-project.yaml
+++ b/config/projects-prod/jhu-ras-pathway-project.yaml
@@ -59,6 +59,6 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/config/projects-prod/mc2-project.yaml
+++ b/config/projects-prod/mc2-project.yaml
@@ -58,6 +58,6 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/config/projects-prod/nfri-ctf-nf1-project.yaml
+++ b/config/projects-prod/nfri-ctf-nf1-project.yaml
@@ -44,6 +44,6 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/config/projects-prod/ntap-add5-project.yaml
+++ b/config/projects-prod/ntap-add5-project.yaml
@@ -33,6 +33,6 @@ stack_tags:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/config/projects-prod/ntap-add6-project.yaml
+++ b/config/projects-prod/ntap-add6-project.yaml
@@ -9,9 +9,9 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14
 
 parameters:
   S3ReadWriteAccessArns:

--- a/config/projects-prod/ntap-cnf-cell-project.yaml
+++ b/config/projects-prod/ntap-cnf-cell-project.yaml
@@ -43,6 +43,6 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/config/projects-prod/robert-allaway-project.yaml
+++ b/config/projects-prod/robert-allaway-project.yaml
@@ -51,6 +51,6 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/config/projects-prod/ucf-dod-nf2-project.yaml
+++ b/config/projects-prod/ucf-dod-nf2-project.yaml
@@ -44,6 +44,6 @@ dependencies:
 sceptre_user_data:
   ManualComputeEnvs:    # use the shared project's forge batch CEs to run pipelines
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14

--- a/docs/configure-tower-projects.md
+++ b/docs/configure-tower-projects.md
@@ -132,7 +132,7 @@ For each valid project configuration file in the specified directory:
 
 ## Compute Environment Versioning
 
-The script uses `CE_VERSION` (i.e. `v13`) to track compute environment versions.
+The script uses `CE_VERSION` (i.e. `v14`) to track compute environment versions.
 When updating CE configurations:
 
 1. Increment `CE_VERSION` in the script

--- a/docs/configure-tower-projects.md
+++ b/docs/configure-tower-projects.md
@@ -136,8 +136,13 @@ The script uses `CE_VERSION` (i.e. `v14`) to track compute environment versions.
 When updating CE configurations:
 
 1. Increment `CE_VERSION` in the script
-2. Run the script to create new CEs with the updated version
-3. Old CEs (not matching the version) are automatically cleaned up
+2. Update the hardcoded version suffix in every `ManualComputeEnvs`
+   `ComputeEnvName` reference in the project configs (e.g.
+   `shared-ce-prod-project-ondemand-v13` -> `-v14`). Projects reference the
+   shared workspace's Batch Forge CEs by name, so the old (now cleaned-up)
+   source CEs would otherwise no longer resolve.
+3. Run the script to create new CEs with the updated version
+4. Old CEs (not matching the version) are automatically cleaned up
 
 ## Skipping Projects
 

--- a/docs/project-config-schema.md
+++ b/docs/project-config-schema.md
@@ -96,9 +96,9 @@ creating its own Batch Forge CEs.
 sceptre_user_data:
   ManualComputeEnvs:
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-ondemand-v13
+      ComputeEnvName: shared-ce-prod-project-ondemand-v14
     - WorkspaceName: shared-ce-prod-project
-      ComputeEnvName: shared-ce-prod-project-spot-v13
+      ComputeEnvName: shared-ce-prod-project-spot-v14
 ```
 
 | Field | Description |


### PR DESCRIPTION
The g5 GPU instance types (g5.xlarge/2xlarge/4xlarge) were added to GPU_EC2_INSTANCE_TYPES in #560, but the deployed v13 compute environments predate that patch (v13 was set in #527, over a month before #560) and CE_VERSION was never bumped. Because check_existing_compute_env() skips any CE whose name already ends in the current CE_VERSION, the live v13 CEs were never re-forged and still lack g5 -- GPU jobs land on the oversized p4d.24xlarge instead of a right-sized single-GPU g5.

Bumping to v14 forces the Batch Forge CEs to be recreated with the current instance-type list (now including g5). Also updates every hardcoded ManualComputeEnvs reference in the project configs so the manual CEs resolve the new v14 source CE names after the old v13 CEs are cleaned up.

depends on #605