### PR TITLE
Add head CPU and compute

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -904,6 +904,8 @@ class TowerWorkspace:
                             "configMode": "Manual",
                             "headQueue": source_ce_head_queue,
                             "computeQueue": source_ce_compute_queue,
+                            "headJobCpus": 8,
+                            "headJobMemoryMb": 15000,
                             "cliPath": "/home/ec2-user/miniconda/bin/aws",
                             "resourceLabelIds": label_ids,
                             "executionRole": source_ce_execution_role,


### PR DESCRIPTION
mcmicro runs in the mc2-project workspace are failing right at startup with Process requirement exceeds available memory -- req: 6 GB; avail: 3.4 GB error. I traced it to undersized Nextflow head-job nodes: a couple of steps (SUMMARY_SAMPLESHEET, and OMEVALIDATION) are designed to run on the head node rather than on Batch workers, and the head node is only ~4 GB, so the 6 GB tasks can't schedule and the run dies before it does any real work.

Cause: our compute envs in this workspace are "manual" CEs, and the script that builds them (configure-tower-projects.py → create_manual_compute_environment()) never sets headJobMemoryMb, so the head node falls back to a tiny ~4 GB instance. The old Batch Forge CEs don't have this problem because they hardcode headJobMemoryMb: 15000 — the manual clone just drops it (and has since manual mode was added in #508, so it's not a v13 regression).

Fix: add headJobCpus: 8 / headJobMemoryMb: 15000 to the manual-CE config block and redeploy.