### PR TITLE
[DPE-1746] Add user to ntap project

### DIFF
--- a/config/projects-prod/ntap-add5-project.yaml
+++ b/config/projects-prod/ntap-add5-project.yaml
@@ -17,6 +17,7 @@ parameters:
     - "{{stack_group_config.tower_viewer_arn_prefix}}/belinda.garana@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/ziwei.pan@sagebase.org"
     - "{{stack_group_config.tower_viewer_arn_prefix}}/adam.taylor@sagebase.org"
+    - "{{stack_group_config.tower_viewer_arn_prefix}}/rixing.xu@sagebase.org"
   AccountAdminArns:
     - "{{stack_group_config.sso_admin_role.arn}}"
     - !stack_output_external sagebase-github-oidc-workflows-prod-nextflow-infra::ProviderRoleArn


### PR DESCRIPTION
## Problem:
The [WES pipelines](https://github.com/sage-bdf/compute-automator/blob/add-wes-somatic-recipe/bulk-wes/sarek_germline_workflow.py) that we will be triggering with the BDF demo data use various files and also credentials from the ntap project workspace on Seqera Platform

## Solution: 
In case permissions is needed (likely if can't migrate to run on bdf prod project), add read/write permissions for Rixing to the ntap seqera project workspace