### PR TITLE
Remove me to resolve CI error

### DIFF
--- a/config/projects-prod/ntap-add5-project.yaml
+++ b/config/projects-prod/ntap-add5-project.yaml
@@ -8,7 +8,6 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/jineta.banerjee@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org'
     - '{{stack_group_config.tower_viewer_arn_prefix}}/christina.conrad@sagebase.org'


### PR DESCRIPTION
There is a build issue  https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/actions/runs/30143686835/job/89641735617

```
[2026-07-25 04:20:34] - projects-prod/ntap-add5-project TowerScratchPolicy AWS::S3::BucketPolicy UPDATE_COMPLETE 
[2026-07-25 04:20:38] - projects-prod/ntap-add5-project ntap-add5-project AWS::CloudFormation::Stack UPDATE_ROLLBACK_IN_PROGRESS Cannot export output S3ReadWriteAccessArns with length 1090. Max length of 1024 exceeded.
[2026-07-25 04:20:42] - projects-prod/ntap-add5-project EncryptionKeyStack AWS::CloudFormation::Stack UPDATE_IN_PROGRESS 
[2026-07-25 04:23:19] - projects-prod/ntap-add5-project EncryptionKeyStack AWS::CloudFormation::Stack UPDATE_COMPLETE 
[2026-07-25 04:23:19] - projects-prod/ntap-add5-project TowerBucketPolicy AWS::S3::BucketPolicy UPDATE_IN_PROGRESS 
[2026-07-25 04:23:19] - projects-prod/ntap-add5-project TowerScratchPolicy AWS::S3::BucketPolicy UPDATE_IN_PROGRESS 
[2026-07-25 04:23:19] - projects-prod/ntap-add5-project TowerBucketPolicy AWS::S3::BucketPolicy UPDATE_COMPLETE 
[2026-07-25 04:23:19] - projects-prod/ntap-add5-project TowerScratchPolicy AWS::S3::BucketPolicy UPDATE_COMPLET
```