### PR TITLE
fix timing issue when processing tower workspaces

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -1301,7 +1301,8 @@ class TowerOrganization:
             if name in self.manual_compute_env_per_project
         ]
 
-        for name, users in source_projects + dependent_projects:
+        ordered_projects = source_projects + dependent_projects
+        for name, users in ordered_projects:
             tags = self.tags_per_project[name]
             manual_compute_envs = self.manual_compute_env_per_project.get(name, [])
             if self.use_teams:

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -1279,11 +1279,29 @@ class TowerOrganization:
     def create_workspaces(self) -> Dict[str, TowerWorkspace]:
         """Create a workspace for each project
 
+        Workspaces that create their own Batch Forge compute environments
+        are processed first, followed by workspaces that reference CEs from
+        other workspaces via ManualComputeEnvs. This ensures that source CEs
+        exist before dependent workspaces try to reference them.
+
         Returns:
             Dict[str, TowerWorkspace]:
                 Mapping of project names and their corresponding workspaces
         """
-        for name, users in self.list_projects():
+        # Process source workspaces (no ManualComputeEnvs) before dependent ones
+        all_projects = list(self.list_projects())
+        source_projects = [
+            (name, users)
+            for name, users in all_projects
+            if name not in self.manual_compute_env_per_project
+        ]
+        dependent_projects = [
+            (name, users)
+            for name, users in all_projects
+            if name in self.manual_compute_env_per_project
+        ]
+
+        for name, users in source_projects + dependent_projects:
             tags = self.tags_per_project[name]
             manual_compute_envs = self.manual_compute_env_per_project.get(name, [])
             if self.use_teams:


### PR DESCRIPTION
Workspaces with ManualComputeEnvs reference CEs created by other workspaces. The previous processing order was non-deterministic (dependent on os.walk), which could result in a dependent workspace being processed before its source workspace had created the referenced CE. This sorts workspaces so Batch Forge CE creators run first, ensuring manual CE references resolve correctly during version bumps.

Example: when bumping CE_VERSION from v13 to v14, example-dev-project references shared-ce-dev-project-ondemand-v14 via ManualComputeEnvs. Previously, example-dev-project could be processed first, failing to find the v14 CE that shared-ce-dev-project hadn't created yet. Now shared-ce-dev-project is always processed first since it has no ManualComputeEnvs dependency.